### PR TITLE
Fix Godot engine fork submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "godot-engine"]
 	path = godot-engine
-	url = git@github.com:the-mirror-megaverse/godot-soft-fork.git # THIS NEEDS TO BE UPDATED WITH THE NEW SOFT FORK REPO
+	url = git@github.com:the-mirror-gdp/godot.git


### PR DESCRIPTION
The URL in `.gitmodules` now points to the open source engine fork: https://github.com/the-mirror-gdp/godot