### PR TITLE
Merge Build and Play into Discover and improve performance of menu

### DIFF
--- a/mirror-godot-app/ui/main_menu/main_menu_ui.gd
+++ b/mirror-godot-app/ui/main_menu/main_menu_ui.gd
@@ -106,7 +106,7 @@ func toggle_main_menu_open(show_space_settings: bool = false) -> void:
 			_audio_stream_player.play()
 			return
 		if show_space_settings:
-			change_page(&"Build")
+			change_page(&"Discover")
 			change_subpage(&"ViewSpace", Zone.space)
 			change_subpage(&"EditSpace", Zone.space)
 		elif GameUI.should_display_space_listings:

--- a/mirror-godot-app/ui/main_menu/main_menu_ui.tscn
+++ b/mirror-godot-app/ui/main_menu/main_menu_ui.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=40 format=3 uid="uid://ch0uw2fa08s6a"]
+[gd_scene load_steps=39 format=3 uid="uid://ch0uw2fa08s6a"]
 
 [ext_resource type="Theme" uid="uid://ggwm8asxintx" path="res://ui/common/themes/menu_ui.theme.tres" id="1_bsgag"]
 [ext_resource type="Script" path="res://ui/main_menu/main_menu_ui.gd" id="2_0tnty"]
@@ -7,7 +7,6 @@
 [ext_resource type="PackedScene" uid="uid://dkowcs24a0rg" path="res://ui/main_menu/pages/my_spaces.tscn" id="6_dxmr5"]
 [ext_resource type="Theme" uid="uid://d1qd6ity2mdpl" path="res://creator/creator_ui.theme.tres" id="7_3j0pc"]
 [ext_resource type="PackedScene" uid="uid://cprw7dhdbphw3" path="res://ui/main_menu/pages/build_spaces.tscn" id="7_al6u3"]
-[ext_resource type="PackedScene" uid="uid://sndmfviwx31d" path="res://ui/main_menu/pages/play_spaces.tscn" id="8_m64q5"]
 [ext_resource type="Shader" path="res://ui/common/shaders/ui_blurr.gdshader" id="8_w8ibq"]
 [ext_resource type="PackedScene" uid="uid://tgcx8ymhgpxe" path="res://ui/main_menu/pages/avatar/avatar.tscn" id="9_aqh2v"]
 [ext_resource type="PackedScene" uid="uid://cx2mo1w80rpi6" path="res://ui/main_menu/pages/settings/settings.tscn" id="10_6f3nv"]
@@ -130,26 +129,23 @@ grow_vertical = 2
 metadata/_edit_use_anchors_ = true
 
 [node name="Home" parent="Pages" instance=ExtResource("4_ra4e2")]
-visible = false
 layout_mode = 1
 
 [node name="My_Spaces" parent="Pages" instance=ExtResource("6_dxmr5")]
 visible = false
 layout_mode = 1
 
-[node name="Build" parent="Pages" instance=ExtResource("7_al6u3")]
+[node name="Discover" parent="Pages" instance=ExtResource("7_al6u3")]
 visible = false
 layout_mode = 1
 theme = ExtResource("7_3j0pc")
-
-[node name="Play" parent="Pages" instance=ExtResource("8_m64q5")]
-layout_mode = 1
 
 [node name="Avatar" parent="Pages" instance=ExtResource("9_aqh2v")]
 visible = false
 layout_mode = 1
 
 [node name="Settings" parent="Pages" instance=ExtResource("10_6f3nv")]
+visible = false
 layout_mode = 1
 
 [node name="HeaderMenu" parent="." instance=ExtResource("10_jeyvr")]

--- a/mirror-godot-app/ui/main_menu/pages/build_spaces.tscn
+++ b/mirror-godot-app/ui/main_menu/pages/build_spaces.tscn
@@ -29,7 +29,7 @@ layout_mode = 1
 _data_source = 1
 
 [node name="Title" parent="Pages/DiscoverSpaceSelect/VBoxContainer/MarginContainer/VBoxContainer" index="1"]
-text = "Build Spaces"
+text = "Discover Spaces"
 
 [node name="ViewSpace" parent="Pages" instance=ExtResource("5_1b50l")]
 visible = false

--- a/mirror-godot-app/ui/main_menu/pages/home_page.gd
+++ b/mirror-godot-app/ui/main_menu/pages/home_page.gd
@@ -1,5 +1,17 @@
 extends Control
 
+@onready var _reloadable_items = [
+	$Pages/HomeSpaceSelect/VBoxContainer/Panel/MarginContainer/ScrollContainer/VBoxContainer/SpacesSectionPopular,
+	$Pages/HomeSpaceSelect/VBoxContainer/Panel/MarginContainer/ScrollContainer/VBoxContainer/SpacesSectionRecents,
+	$Pages/HomeSpaceSelect/VBoxContainer/Panel/MarginContainer/ScrollContainer/VBoxContainer/SpacesSectionFavorites,
+	$Pages/HomeSpaceSelect/VBoxContainer/Panel/MarginContainer/ScrollContainer/VBoxContainer/SpacesSectionMy
+]
+
 
 func _on_view_my_spaces_pressed():
 	GameUI.main_menu_ui.change_page(&"My_Spaces")
+
+
+func _on_reload_pressed():
+	for home_page_section in _reloadable_items:
+		home_page_section.fetch_and_populate()

--- a/mirror-godot-app/ui/main_menu/pages/home_page.tscn
+++ b/mirror-godot-app/ui/main_menu/pages/home_page.tscn
@@ -18,6 +18,8 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
 theme = ExtResource("1_ddtg3")
 script = ExtResource("1_g044v")
 
@@ -40,7 +42,6 @@ theme_override_constants/margin_left = 50
 theme_override_constants/margin_top = 50
 theme_override_constants/margin_right = 50
 theme_override_constants/margin_bottom = 50
-metadata/_edit_use_anchors_ = true
 
 [node name="VBoxContainer" type="VBoxContainer" parent="Pages/HomeSpaceSelect"]
 layout_mode = 2

--- a/mirror-godot-app/ui/main_menu/pages/home_page.tscn
+++ b/mirror-godot-app/ui/main_menu/pages/home_page.tscn
@@ -1,11 +1,13 @@
-[gd_scene load_steps=8 format=3 uid="uid://0mra323xtoht"]
+[gd_scene load_steps=10 format=3 uid="uid://0mra323xtoht"]
 
+[ext_resource type="Theme" uid="uid://d1qd6ity2mdpl" path="res://creator/creator_ui.theme.tres" id="1_ddtg3"]
 [ext_resource type="Script" path="res://ui/main_menu/pages/home_page.gd" id="1_g044v"]
 [ext_resource type="Texture2D" uid="uid://dado8tm3ai4q" path="res://ui/common/images/logo-default.svg" id="2_byxtm"]
 [ext_resource type="PackedScene" uid="uid://48n8qruuys5w" path="res://ui/main_menu/pages/home/home_spaces_section.tscn" id="2_l3jcy"]
 [ext_resource type="PackedScene" uid="uid://d0ritou4okory" path="res://ui/main_menu/pages/home/home_space_panel_empty.tscn" id="3_scd2x"]
 [ext_resource type="PackedScene" uid="uid://bxip7xuk82fsr" path="res://ui/main_menu/pages/view_space.tscn" id="4_57sjc"]
 [ext_resource type="PackedScene" uid="uid://brrda4tvbd43x" path="res://ui/main_menu/pages/edit_space/edit_space.tscn" id="6_duhnl"]
+[ext_resource type="FontFile" uid="uid://cv5tkor0qdxqq" path="res://ui/common/fonts/fontawesome-free-6/Font Awesome 6 Free-Solid-900.otf" id="6_por32"]
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_tw1n3"]
 
@@ -16,6 +18,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+theme = ExtResource("1_ddtg3")
 script = ExtResource("1_g044v")
 
 [node name="Pages" type="Control" parent="."]
@@ -110,10 +113,23 @@ layout_mode = 2
 empty_item_scene = ExtResource("3_scd2x")
 _include_localhost_item = true
 
-[node name="Create" type="Button" parent="Pages/HomeSpaceSelect/VBoxContainer/Panel/MarginContainer/ScrollContainer/VBoxContainer/SpacesSectionPopular/TitleBar" index="1"]
-custom_minimum_size = Vector2(0, 40)
+[node name="HBoxContainer" type="HBoxContainer" parent="Pages/HomeSpaceSelect/VBoxContainer/Panel/MarginContainer/ScrollContainer/VBoxContainer/SpacesSectionPopular/TitleBar" index="1"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="Reload" type="Button" parent="Pages/HomeSpaceSelect/VBoxContainer/Panel/MarginContainer/ScrollContainer/VBoxContainer/SpacesSectionPopular/TitleBar/HBoxContainer"]
+custom_minimum_size = Vector2(16, 16)
 layout_mode = 2
 size_flags_horizontal = 10
+theme = ExtResource("1_ddtg3")
+theme_override_fonts/font = ExtResource("6_por32")
+theme_override_font_sizes/font_size = 16
+text = ":refresh:"
+
+[node name="Create" type="Button" parent="Pages/HomeSpaceSelect/VBoxContainer/Panel/MarginContainer/ScrollContainer/VBoxContainer/SpacesSectionPopular/TitleBar/HBoxContainer"]
+custom_minimum_size = Vector2(0, 40)
+layout_mode = 2
+size_flags_horizontal = 8
 text = "+ New Space"
 
 [node name="SpacesSectionRecents" parent="Pages/HomeSpaceSelect/VBoxContainer/Panel/MarginContainer/ScrollContainer/VBoxContainer" instance=ExtResource("2_l3jcy")]
@@ -136,9 +152,9 @@ _include_new_space_item = true
 layout_mode = 2
 size_flags_horizontal = 10
 theme_override_colors/font_color = Color(0.333333, 1, 0.831373, 1)
+theme_override_colors/font_focus_color = Color(0.333333, 1, 0.831373, 1)
 theme_override_colors/font_pressed_color = Color(0.333333, 1, 0.831373, 1)
 theme_override_colors/font_hover_color = Color(0.333333, 0.952941, 1, 1)
-theme_override_colors/font_focus_color = Color(0.333333, 1, 0.831373, 1)
 theme_override_colors/font_hover_pressed_color = Color(0.333333, 1, 0.831373, 1)
 text = "VIEW ALL"
 flat = true
@@ -153,7 +169,8 @@ visible = false
 layout_mode = 1
 offset_top = 80.0
 
-[connection signal="pressed" from="Pages/HomeSpaceSelect/VBoxContainer/Panel/MarginContainer/ScrollContainer/VBoxContainer/SpacesSectionPopular/TitleBar/Create" to="Pages/HomeSpaceSelect/VBoxContainer/Panel/MarginContainer/ScrollContainer/VBoxContainer/SpacesSectionPopular" method="_on_create_pressed"]
+[connection signal="pressed" from="Pages/HomeSpaceSelect/VBoxContainer/Panel/MarginContainer/ScrollContainer/VBoxContainer/SpacesSectionPopular/TitleBar/HBoxContainer/Reload" to="." method="_on_reload_pressed"]
+[connection signal="pressed" from="Pages/HomeSpaceSelect/VBoxContainer/Panel/MarginContainer/ScrollContainer/VBoxContainer/SpacesSectionPopular/TitleBar/HBoxContainer/Create" to="Pages/HomeSpaceSelect/VBoxContainer/Panel/MarginContainer/ScrollContainer/VBoxContainer/SpacesSectionPopular" method="_on_create_pressed"]
 [connection signal="pressed" from="Pages/HomeSpaceSelect/VBoxContainer/Panel/MarginContainer/ScrollContainer/VBoxContainer/SpacesSectionMy/TitleBar/ViewMySpaces" to="." method="_on_view_my_spaces_pressed"]
 
 [editable path="Pages/HomeSpaceSelect/VBoxContainer/Panel/MarginContainer/ScrollContainer/VBoxContainer/SpacesSectionPopular"]

--- a/mirror-godot-app/ui/main_menu/pages/home_page_section.gd
+++ b/mirror-godot-app/ui/main_menu/pages/home_page_section.gd
@@ -194,11 +194,13 @@ func _ready() -> void:
 	visibility_changed.connect(_on_visibility_changed, CONNECT_DEFERRED)
 	get_tree().get_root().size_changed.connect(_on_resized)
 
-
+var _first_refresh_completed = false
 func _on_visibility_changed() -> void:
 	if not is_visible_in_tree():
 		return
-	fetch_and_populate()
+	if not _first_refresh_completed:
+		fetch_and_populate()
+		_first_refresh_completed = true
 
 
 func _on_resized() -> void:

--- a/mirror-godot-app/ui/main_menu/pages/home_page_section.gd
+++ b/mirror-godot-app/ui/main_menu/pages/home_page_section.gd
@@ -194,14 +194,11 @@ func _ready() -> void:
 	visibility_changed.connect(_on_visibility_changed, CONNECT_DEFERRED)
 	get_tree().get_root().size_changed.connect(_on_resized)
 
-var _first_refresh_completed = false
 func _on_visibility_changed() -> void:
 	if not is_visible_in_tree():
 		return
-	if not _first_refresh_completed:
-		fetch_and_populate()
-		_first_refresh_completed = true
+	await fetch_and_populate()
 
 
 func _on_resized() -> void:
-	_on_visibility_changed()
+	await _on_visibility_changed()

--- a/mirror-godot-app/ui/main_menu/pages/my_spaces.tscn
+++ b/mirror-godot-app/ui/main_menu/pages/my_spaces.tscn
@@ -32,9 +32,8 @@ item_width = 376
 
 [node name="MySpaceSelect" parent="Pages" instance=ExtResource("2_38vl8")]
 layout_mode = 1
-_data_source = 0
 
-[node name="NewButton" type="Button" parent="Pages/MySpaceSelect/VBoxContainer/MarginContainer/VBoxContainer/HBoxContainer" index="2"]
+[node name="NewButton" type="Button" parent="Pages/MySpaceSelect/VBoxContainer/MarginContainer/VBoxContainer/HBoxContainer" index="3"]
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 text = "+ New Space"

--- a/mirror-godot-app/ui/main_menu/pages/space_select.gd
+++ b/mirror-godot-app/ui/main_menu/pages/space_select.gd
@@ -127,15 +127,17 @@ func _reset():
 		return
 	_endless_scroll_flow_container.setup(size)
 
+var _first_refresh_completed = false
 
 func _on_visibility_changed() -> void:
 	if not is_visible_in_tree():
 		_last_visibility_state = false
 		return
 	# Do not refresh if state changed from visible to visible
-	if _last_visibility_state != true:
+	if _last_visibility_state != true and not _first_refresh_completed:
 		_reset()
 		_last_visibility_state = true
+		_first_refresh_completed = true
 
 
 func _is_able_to_refresh() -> bool:
@@ -186,3 +188,7 @@ func _on_source_option_button_item_selected(index):
 func populate(search: String) -> void:
 	_search_field.set_text(search)
 	on_search_title(search)
+
+
+func _on_refresh_pressed():
+	_reset()

--- a/mirror-godot-app/ui/main_menu/pages/space_select.tscn
+++ b/mirror-godot-app/ui/main_menu/pages/space_select.tscn
@@ -1,10 +1,12 @@
-[gd_scene load_steps=12 format=3 uid="uid://b6kuvk63etfpw"]
+[gd_scene load_steps=14 format=3 uid="uid://b6kuvk63etfpw"]
 
 [ext_resource type="Script" path="res://ui/main_menu/pages/space_select.gd" id="1_1ynam"]
 [ext_resource type="PackedScene" uid="uid://cvyh06rrrcdyc" path="res://ui/main_menu/common/space_panel.tscn" id="2_ed1sy"]
 [ext_resource type="PackedScene" uid="uid://7geveyvf002c" path="res://ui/common/components/endless_scroll_flow_container.tscn" id="3_68pjp"]
 [ext_resource type="FontFile" uid="uid://dhpbqmk3ulim4" path="res://ui/common/fonts/montserrat/montserrat_bold.ttf" id="3_xdod4"]
 [ext_resource type="PackedScene" uid="uid://bahpo436m8hut" path="res://creator/asset_inventory/browser/search_field.tscn" id="4_atsy6"]
+[ext_resource type="Theme" uid="uid://d1qd6ity2mdpl" path="res://creator/creator_ui.theme.tres" id="4_othw4"]
+[ext_resource type="FontFile" uid="uid://cv5tkor0qdxqq" path="res://ui/common/fonts/fontawesome-free-6/Font Awesome 6 Free-Solid-900.otf" id="5_4vfgi"]
 [ext_resource type="AudioStream" uid="uid://b1wqy8isen5sg" path="res://audio/mouseclick.wav" id="6_jogvj"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_to6xd"]
@@ -18,23 +20,23 @@ corner_radius_top_right = 5
 corner_radius_bottom_right = 5
 corner_radius_bottom_left = 5
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_0gnba"]
-content_margin_left = 8.0
-content_margin_top = 12.0
-content_margin_right = 8.0
-content_margin_bottom = 0.0
-bg_color = Color(0, 0, 0, 0.6)
-corner_radius_top_left = 5
-corner_radius_top_right = 5
-corner_radius_bottom_right = 5
-corner_radius_bottom_left = 5
-
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_44eih"]
 content_margin_left = 8.0
 content_margin_top = 12.0
 content_margin_right = 8.0
 content_margin_bottom = 0.0
 bg_color = Color(0, 0, 0, 0.8)
+corner_radius_top_left = 5
+corner_radius_top_right = 5
+corner_radius_bottom_right = 5
+corner_radius_bottom_left = 5
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_0gnba"]
+content_margin_left = 8.0
+content_margin_top = 12.0
+content_margin_right = 8.0
+content_margin_bottom = 0.0
+bg_color = Color(0, 0, 0, 0.6)
 corner_radius_top_left = 5
 corner_radius_top_right = 5
 corner_radius_bottom_right = 5
@@ -107,9 +109,9 @@ unique_name_in_owner = true
 layout_mode = 2
 theme_override_font_sizes/font_size = 13
 theme_override_styles/focus = SubResource("StyleBoxFlat_to6xd")
-theme_override_styles/normal = SubResource("StyleBoxFlat_0gnba")
 theme_override_styles/hover = SubResource("StyleBoxFlat_44eih")
 theme_override_styles/pressed = SubResource("StyleBoxFlat_44eih")
+theme_override_styles/normal = SubResource("StyleBoxFlat_0gnba")
 item_count = 2
 selected = 0
 popup/item_0/text = "Popular"
@@ -125,6 +127,14 @@ offset_right = 41.0
 offset_bottom = 18.0
 text = "Sort by"
 label_settings = SubResource("LabelSettings_p2v8i")
+
+[node name="Refresh" type="Button" parent="VBoxContainer/MarginContainer/VBoxContainer/HBoxContainer"]
+custom_minimum_size = Vector2(32, 32)
+layout_mode = 2
+theme = ExtResource("4_othw4")
+theme_override_fonts/font = ExtResource("5_4vfgi")
+theme_override_font_sizes/font_size = 16
+text = ":refresh:"
 
 [node name="SearchField" parent="VBoxContainer/MarginContainer/VBoxContainer/HBoxContainer" instance=ExtResource("4_atsy6")]
 unique_name_in_owner = true
@@ -171,6 +181,7 @@ stream = ExtResource("6_jogvj")
 volume_db = -10.0
 
 [connection signal="item_selected" from="VBoxContainer/MarginContainer/VBoxContainer/HBoxContainer/SourceOptionButton" to="." method="_on_source_option_button_item_selected"]
+[connection signal="pressed" from="VBoxContainer/MarginContainer/VBoxContainer/HBoxContainer/Refresh" to="." method="_on_refresh_pressed"]
 [connection signal="text_changed" from="VBoxContainer/MarginContainer/VBoxContainer/HBoxContainer/SearchField" to="." method="on_search_title"]
 
 [editable path="VBoxContainer/Panel/MarginContainer/EndlessScrollFlowContainer"]


### PR DESCRIPTION
- Do not reload page on opening a tab (home page & discover)
- Merge Build and Play into Discover.
- Added refresh icon for reloading the space list.
- Added refresh icon for reloading the home page.
- Fixed popular list of spaces to show the discover content