### PR TITLE
Add automated upload of the editor binary

### DIFF
--- a/.github/actions/upload-artifact/action.yml
+++ b/.github/actions/upload-artifact/action.yml
@@ -1,0 +1,21 @@
+name: Upload Godot artifact
+description: Upload the Godot artifact.
+inputs:
+  name:
+    description: The artifact name.
+    default: "${{ github.job }}"
+  path:
+    description: The path to upload.
+    required: true
+    default: "bin/*"
+runs:
+  using: "composite"
+  steps:
+    - name: Upload Godot Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ inputs.path }}
+        retention-days: 14
+        if-no-files-found: error
+

--- a/.github/workflows/linux_builds_deployment.yml
+++ b/.github/workflows/linux_builds_deployment.yml
@@ -3,6 +3,7 @@ on:
   push:
     paths:
     - godot-engine/**
+    - .github/**
 
 defaults:
   run:
@@ -101,3 +102,9 @@ jobs:
           chmod +x bin/godot.*
           mv ${{ matrix.bin }} bin/${{ matrix.artifact-name }}
 
+      - name: Upload artifact
+        uses: ./.github/actions/upload-artifact
+        if: ${{ matrix.artifact }}
+        with:
+          path: bin/${{ matrix.artifact-name }}
+          name: ${{ matrix.artifact-name }}

--- a/.github/workflows/linux_builds_deployment.yml
+++ b/.github/workflows/linux_builds_deployment.yml
@@ -106,5 +106,5 @@ jobs:
         uses: ./.github/actions/upload-artifact
         if: ${{ matrix.artifact }}
         with:
-          path: bin/${{ matrix.artifact-name }}
+          path: ./godot-engine/bin/${{ matrix.artifact-name }}
           name: ${{ matrix.artifact-name }}

--- a/.github/workflows/macos_builds_deployment.yml
+++ b/.github/workflows/macos_builds_deployment.yml
@@ -137,4 +137,4 @@ jobs:
         uses: ./.github/actions/upload-artifact
         with:
           name: "${{ matrix.artifact-name }}.zip"
-          path: "bin/${{ matrix.artifact-name }}.zip"
+          path: "./godot-engine/bin/${{ matrix.artifact-name }}.zip"

--- a/.github/workflows/macos_builds_deployment.yml
+++ b/.github/workflows/macos_builds_deployment.yml
@@ -3,6 +3,7 @@ on:
   push:
     paths:
     - godot-engine/**
+    - .github/**
 
 defaults:
   run:
@@ -131,3 +132,9 @@ jobs:
           chmod -R +x ${{ matrix.packaged-app }}
           xattr -rc ${{ matrix.packaged-app }}
           zip -q -9 -r ${{ matrix.artifact-name }}.zip ${{ matrix.packaged-app }}
+
+      - name: Upload artifact
+        uses: ./.github/actions/upload-artifact
+        with:
+          name: "${{ matrix.artifact-name }}.zip"
+          path: "bin/${{ matrix.artifact-name }}.zip"

--- a/.github/workflows/windows_builds_deployment.yml
+++ b/.github/workflows/windows_builds_deployment.yml
@@ -3,6 +3,7 @@ on:
   push:
     paths:
     - godot-engine/**
+    - .github/**
 
 defaults:
   run:
@@ -94,4 +95,9 @@ jobs:
         run: |
           mv ${{ matrix.bin }}.exe bin/${{ matrix.artifact-name }}.exe
 
-
+      - name: Upload artifact
+        uses: ./.github/actions/upload-artifact
+        if: ${{ matrix.artifact }}
+        with:
+          path: bin/${{ matrix.artifact-name }}.exe
+          name: ${{ matrix.artifact-name }}.exe

--- a/.github/workflows/windows_builds_deployment.yml
+++ b/.github/workflows/windows_builds_deployment.yml
@@ -99,5 +99,5 @@ jobs:
         uses: ./.github/actions/upload-artifact
         if: ${{ matrix.artifact }}
         with:
-          path: bin/${{ matrix.artifact-name }}.exe
+          path: ./godot-engine/bin/${{ matrix.artifact-name }}.exe
           name: ${{ matrix.artifact-name }}.exe


### PR DESCRIPTION
We can use github for now and if we have any issues we can deploy them direct to releases so they do not get removed.