### PR TITLE
Add reliable engine binary retrieval

### DIFF
--- a/.github/workflows/client-build-tool.yml
+++ b/.github/workflows/client-build-tool.yml
@@ -96,6 +96,12 @@ on:
       custom-project-file:
         required: false
         type: string
+      editor-download-url:
+        required: true
+        type: string
+      template-download-url:
+        required: true
+        type: string
     outputs:
       url:
         value: ${{ jobs.client-build-tool.outputs.url }}
@@ -158,26 +164,15 @@ jobs:
           rm -Rf project.godot
           mv ${{ inputs.custom-project-file }} project.godot
 
-      - name: Download editor artifact
-        uses: dawidd6/action-download-artifact@v3
-        with:
-          github_token: ${{ secrets.cicd-token-github }}
-          workflow: ${{ inputs.editor-binary-workflow }}
-          workflow_conclusion: "in_progress"
-          name: ${{ inputs.editor-binary-download }}
+      - name: Download editor and template
+        run: |
+          curl ${{ inputs.editor-download-url }} > ${{ inputs.editor-binary-download }}
+          curl ${{ inputs.template-download-url }} > ${{ inputs.template-binary-name }}
 
       - name: Unzip editor binary
         if: ${{ inputs.should-unzip-editor }}
         run: |
           unzip -o ${{ inputs.editor-binary-download }}
-
-      - name: Download export template artifact
-        uses: dawidd6/action-download-artifact@v3
-        with:
-          github_token: ${{ secrets.cicd-token-github }}
-          workflow: ${{ inputs.template-binary-workflow }}
-          workflow_conclusion: "in_progress" # must be in_progress otherwise we can't find them for our current job 
-          name: ${{ inputs.template-binary-name }}
 
       - name: Set up template in system-wide editor data
         run: |

--- a/.github/workflows/deployment-pr.yml
+++ b/.github/workflows/deployment-pr.yml
@@ -1,8 +1,10 @@
-name: Deployment
+name: PR Deployment
 on:
-  push:
-    tags:
-      - 'v*'
+  pull_request:
+    paths:
+    - godot-engine/**
+    - .github/**
+    - mirror-godot-app/**
 
 concurrency:
   # workflow name - PR || fallback to unique run id, this happens when you're not building a PR
@@ -11,20 +13,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  get-or-build-engine:
-    name: Building Engine
-    uses: ./.github/workflows/engine.yml
-    secrets:
-      GCP_BUCKET_UPLOAD: ${{ secrets.GCP_BUCKET_UPLOAD }}
-    with:
-      environment: "dev"
-
   build-windows-client:
     name: 🏁 Build Windows Dev PR
     uses: ./.github/workflows/client-build-tool.yml
-    needs: get-or-build-engine
     secrets:
-      gcp-secret: ${{ secrets.GCP_BUCKET_UPLOAD }}
+      gcp-secret: ""
       cicd-token-github: ${{ secrets.GITHUB_TOKEN }}
     with:
       should-deploy: false
@@ -44,12 +37,12 @@ jobs:
       game-binary-name: The Mirror Dev.exe
       bucket-name: no-bucket
       os: "windows-latest"
-      editor-download-url: https://storage.googleapis.com/mirror_native_client_builds/Engine/${{needs.get-or-build-engine.outputs.commit_hash}}/MirrorGodotEditorWindows.exe
-      template-download-url: https://storage.googleapis.com/mirror_native_client_builds/Engine/${{needs.get-or-build-engine.outputs.commit_hash}}/windows_release_x86_64.exe
+      # TODO: This will be dynamic in future and we can't do that immediately as we have to focus on the deployment side.
+      editor-download-url: https://storage.googleapis.com/mirror_native_client_builds/Engine/4309e8e8/MirrorGodotEditorWindows.exe
+      template-download-url: https://storage.googleapis.com/mirror_native_client_builds/Engine/4309e8e8/windows_release_x86_64.exe
   build-macos-client:
     name: 🍎 Build MacOS Dev PR
     uses: ./.github/workflows/client-build-tool.yml
-    needs: get-or-build-engine
     secrets:
       gcp-secret: ""
       cicd-token-github: ${{ secrets.GITHUB_TOKEN }}
@@ -73,12 +66,12 @@ jobs:
       game-binary-name: The Mirror Dev.app
       bucket-name: no-bucket
       os: "macos-latest"
-      editor-download-url: https://storage.googleapis.com/mirror_native_client_builds/Engine/${{needs.get-or-build-engine.outputs.commit_hash}}/MirrorGodotEditorMac.app.zip
-      template-download-url: https://storage.googleapis.com/mirror_native_client_builds/Engine/${{needs.get-or-build-engine.outputs.commit_hash}}/macos_template.app.zip
+      # TODO: This will be dynamic in future and we can't do that immediately as we have to focus on the deployment side.
+      editor-download-url: https://storage.googleapis.com/mirror_native_client_builds/Engine/4309e8e8/MirrorGodotEditorMac.app.zip
+      template-download-url: https://storage.googleapis.com/mirror_native_client_builds/Engine/4309e8e8/macos_template.app.zip
   build-linux-client:
     name: 🐧 Build Linux Dev PR
     uses: ./.github/workflows/client-build-tool.yml
-    needs: get-or-build-engine
     secrets:
       gcp-secret: ""
       cicd-token-github: ${{ secrets.GITHUB_TOKEN }}
@@ -100,5 +93,6 @@ jobs:
       game-binary-name: The Mirror Dev.x86_64
       bucket-name: no-bucket
       os: "ubuntu-20.04"
-      editor-download-url: https://storage.googleapis.com/mirror_native_client_builds/Engine/${{needs.get-or-build-engine.outputs.commit_hash}}/MirrorGodotEditorLinux.x86_64
-      template-download-url: https://storage.googleapis.com/mirror_native_client_builds/Engine/${{needs.get-or-build-engine.outputs.commit_hash}}/linux_release.x86_64
+      # TODO: This will be dynamic in future and we can't do that immediately as we have to focus on the deployment side.
+      editor-download-url: https://storage.googleapis.com/mirror_native_client_builds/Engine/4309e8e8/MirrorGodotEditorLinux.x86_64
+      template-download-url: https://storage.googleapis.com/mirror_native_client_builds/Engine/4309e8e8/linux_release.x86_64

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -9,10 +9,6 @@ on:
     - .github/**
     - mirror-godot-app/**
 
-defaults:
-  run:
-    working-directory: ./godot-engine
-
 concurrency:
   # workflow name - PR || fallback to unique run id, this happens when you're not building a PR
   # this ensures all branches build properly and cancel their previous runs

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -24,6 +24,7 @@ jobs:
     name: Building Engine
     runs-on: "ubuntu-20.04"
     steps:
+      - uses: actions/checkout@v4
       - name: build engine
         uses: ./.github/workflows/engine.yml
         with:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -13,15 +13,6 @@ defaults:
   run:
     working-directory: ./godot-engine
 
-# Global Settings
-env:
-  # Used for the cache key. Add version suffix to force clean build.
-  GODOT_BASE_BRANCH: master
-  SCONSFLAGS: verbose=yes warnings=extra werror=no module_text_server_fb_enabled=yes fontconfig=no
-  DOTNET_NOLOGO: true
-  DOTNET_CLI_TELEMETRY_OPTOUT: true
-  TSAN_OPTIONS: suppressions=misc/error_suppressions/tsan.txt
-
 concurrency:
   # workflow name - PR || fallback to unique run id, this happens when you're not building a PR
   # this ensures all branches build properly and cancel their previous runs
@@ -29,286 +20,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-windows:
-    runs-on: "windows-latest"
-    name: ${{ matrix.name }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: Windows Editor
-            cache-name: windows-editor
-            target: editor
-            strip: true
-            tests: false
-            sconsflags: arch=x86_64 debug_symbols=no windows_subsystem=console optimize=speed production=yes
-            bin: "./bin/godot.windows.editor.x86_64"
-            artifact-name: "MirrorGodotEditorWindows"
-            artifact: true
-
-          - name: Windows Template
-            cache-name: windows-template
-            target: template_debug
-            strip: true
-            tests: false
-            sconsflags: arch=x86_64 debug_symbols=no optimize=speed
-            bin: "./bin/godot.windows.template_debug.x86_64"
-            artifact-name: "windows_release_x86_64"
-            artifact: true
-
+  get-or-build-engine:
+    name: Building Engine
+    runs-on: "ubuntu-20.04"
     steps:
-      - uses: actions/checkout@v4
+      - name: build engine
+        uses: ./.github/workflows/engine.yml
         with:
-          submodules: recursive
+          cicd-token-github: ${{ secrets.GCP_BUCKET_UPLOAD }}
 
-      - name: Setup Godot build cache
-        uses: ./godot-engine/.github/actions/godot-cache
-        with:
-          cache-name: ${{ matrix.cache-name }}
-        continue-on-error: true
-
-      - name: Setup python and scons
-        uses: ./godot-engine/.github/actions/godot-deps
-
-      #- name: Download Direct3D 12 SDK components
-      #  run: python ./misc/scripts/install_d3d12_sdk_windows.py
-
-      - name: Setup MSVC problem matcher
-        uses: ammaraskar/msvc-problem-matcher@master
-
-      - name: Compilation
-        uses: ./.github/actions/godot-build
-        with:
-          sconsflags: ${{ env.SCONSFLAGS }} ${{ matrix.sconsflags }}
-          platform: windows
-          target: ${{ matrix.target }}
-          tests: ${{ matrix.tests }}
-
-      - name: Strip binaries
-        if: ${{ matrix.strip }}
-        run: |
-          Remove-Item bin/* -Include *.exp,*.lib,*.pdb -Force
-
-      - name: Move PDB file (if not stripped)
-        if: ${{ !matrix.strip }}
-        run: |
-          dir -Path ./bin/
-          mv ${{matrix.bin}}.pdb bin/${{ matrix.artifact-name}}.pdb
-
-      - name: Prepare artifact
-        if: ${{ matrix.artifact }}
-        run: |
-          mv ${{ matrix.bin }}.exe bin/${{ matrix.artifact-name }}.exe
-
-      - name: Upload artifact
-        uses: ./.github/actions/upload-artifact
-        if: ${{ matrix.artifact }}
-        with:
-          path: ./godot-engine/bin/${{ matrix.artifact-name }}.exe
-          name: ${{ matrix.artifact-name }}.exe
-  build-macos:
-    runs-on: "macos-latest"
-    name: ${{ matrix.name }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: MacOS Editor
-            cache-name: macos-editor
-            target: editor
-            tests: false
-            strip: true
-            sconsflags: debug_symbols=no optimize=speed production=yes
-            dist-app: "macos_tools.app"
-            packaged-app: "MirrorGodotEditorMac.app"
-            bin-name: "godot.macos.editor.universal"
-            bin-name-x86_64: "godot.macos.editor.x86_64"
-            bin-name-arm64: "godot.macos.editor.arm64"
-            artifact-bin-name: "Godot"
-            artifact-name: "MirrorGodotEditorMac.app"
-
-          - name: MacOS Template
-            cache-name: macos-template
-            target: template_debug
-            tests: false
-            strip: true
-            sconsflags: debug_symbols=no optimize=speed
-            dist-app: "macos_template.app"
-            packaged-app: "macos_template.app"
-            bin-name: "godot.macos.template_debug.universal"
-            bin-name-x86_64: "godot.macos.template_debug.x86_64"
-            bin-name-arm64: "godot.macos.template_debug.arm64"
-            artifact-bin-name: "godot_macos_release.universal"
-            artifact-name: "macos_template.app"
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - name: Setup python and scons
-        uses: ./godot-engine/.github/actions/godot-deps
-      - name: Setup Vulkan SDK
-        run: |
-          # Download and install the Vulkan SDK.
-          curl -L "https://sdk.lunarg.com/sdk/download/latest/mac/vulkan-sdk.dmg" -o /tmp/vulkan-sdk.dmg
-          hdiutil attach /tmp/vulkan-sdk.dmg -mountpoint /Volumes/vulkan-sdk
-          /Volumes/vulkan-sdk/InstallVulkan.app/Contents/MacOS/InstallVulkan \
-              --accept-licenses --default-answer --confirm-command install
-
-      - name: Setup Godot build cache
-        uses: ./godot-engine/.github/actions/godot-cache
-        with:
-          cache-name: ${{ matrix.cache-name }}
-        continue-on-error: true
-
-      - name: Setup scons (python is already installed on self-hosted runners!)
-        shell: bash
-        run: |
-          python3 -c "import sys; print(sys.version)"
-          python3 -m ensurepip --upgrade
-          python3 -m pip install --user scons
-          scons --version
-
-      - name: Setup cmake
-        shell: bash
-        run: |
-          brew install cmake
-          cmake --version
-
-      - name: Remove existing binaries
-        run: |
-          rm -Rf bin/
-
-      - name: Compilation (x86_64)
-        uses: ./.github/actions/godot-build
-        with:
-          sconsflags: ${{ env.SCONSFLAGS }} arch=x86_64
-          platform: macos
-          target: ${{ matrix.target }}
-          tests: ${{ matrix.tests }}
-
-      - name: Compilation (arm64)
-        uses: ./.github/actions/godot-build
-        with:
-          sconsflags: ${{ env.SCONSFLAGS }} arch=arm64
-          platform: macos
-          target: ${{ matrix.target }}
-          tests: ${{ matrix.tests }}
-
-      - name: Strip binaries
-        if: ${{ matrix.strip }}
-        run: |
-          echo "Stripping binaries"
-          strip bin/*
-
-      - name: Prepare universal executable
-        run: |
-          lipo -create bin/${{ matrix.bin-name-x86_64 }} bin/${{ matrix.bin-name-arm64 }} -output bin/${{ matrix.bin-name }}
-          chmod -R +x bin/*
-
-      - name: Package in macOS app bundle
-        shell: sh
-        run: |
-          cp -R misc/dist/${{ matrix.dist-app }} bin/${{ matrix.packaged-app }}
-          cd bin/
-          mkdir -p ${{ matrix.packaged-app }}/Contents/MacOS
-          cp ${{ matrix.bin-name }} ${{ matrix.packaged-app }}/Contents/MacOS/${{ matrix.artifact-bin-name }}
-          chmod -R +x ${{ matrix.packaged-app }}
-          xattr -rc ${{ matrix.packaged-app }}
-          zip -q -9 -r ${{ matrix.artifact-name }}.zip ${{ matrix.packaged-app }}
-
-      - name: Upload artifact
-        uses: ./.github/actions/upload-artifact
-        with:
-          name: "${{ matrix.artifact-name }}.zip"
-          path: "./godot-engine/bin/${{ matrix.artifact-name }}.zip"
-  build-linux:
-    runs-on: "ubuntu-20.04" # MUST run on the old version for GLIBC compatibility
-    name: ${{ matrix.name }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: Linux Editor
-            cache-name: linux-editor
-            target: editor
-            sconsflags: arch=x86_64 debug_symbols=no optimize=speed production=yes
-            strip: false
-            bin: "./bin/godot.linuxbsd.editor.x86_64"
-            artifact-name: "MirrorGodotEditorLinux.x86_64"
-            artifact: true
-            tests: no
-
-          - name: Linux Template
-            cache-name: linux-template
-            target: template_debug
-            strip: true
-            sconsflags: arch=x86_64 debug_symbols=no optimize=speed
-            bin: "./bin/godot.linuxbsd.template_debug.x86_64"
-            artifact-name: "linux_release.x86_64"
-            artifact: true
-            tests: no
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Setup Godot build cache
-        uses: ./godot-engine/.github/actions/godot-cache
-        with:
-          cache-name: ${{ matrix.cache-name }}
-        continue-on-error: true
-
-      - name: Setup scons
-        shell: bash
-        run: |
-          python -c "import sys; print(sys.version)"
-          python -m pip install scons==4.4.0
-          scons --version
-
-      - name: Setup GCC problem matcher
-        uses: ammaraskar/gcc-problem-matcher@master
-
-      - name: Compilation
-        uses: ./.github/actions/godot-build
-        with:
-          sconsflags: ${{ env.SCONSFLAGS }} ${{ matrix.sconsflags }}
-          platform: linuxbsd
-          target: ${{ matrix.target }}
-          tests: ${{ matrix.tests }}
-
-      - name: Strip binaries
-        if: ${{ matrix.strip }}
-        run: |
-          strip bin/godot.*
-
-      # - name: Shrink debug symbols
-      #   if: ${{ !matrix.strip }}
-      #   run: |
-      #     # remove duplicate symbols from binary
-      #     dwz ${{ matrix.bin }} -L none -o Middleman.debug
-      #     # make the debug symbols compressed
-      #     objcopy --compress-debug-sections Middleman.debug FinalMan.debug
-      #     # overwrite the original file
-      #     mv FinalMan.debug ${{ matrix.bin }}
-
-      - name: Prepare artifact
-        if: ${{ matrix.artifact }}
-        run: |
-          chmod +x bin/godot.*
-          mv ${{ matrix.bin }} bin/${{ matrix.artifact-name }}
-
-      - name: Upload artifact
-        uses: ./.github/actions/upload-artifact
-        if: ${{ matrix.artifact }}
-        with:
-          path: ./godot-engine/bin/${{ matrix.artifact-name }}
-          name: ${{ matrix.artifact-name }}
   build-windows-client:
     name: 🏁 Build Windows Dev PR
     uses: ./.github/workflows/client-build-tool.yml
-    needs: build-windows
+    needs: get-or-build-engine
     secrets:
       gcp-secret: ""
       cicd-token-github: ${{ secrets.GITHUB_TOKEN }}
@@ -330,56 +54,58 @@ jobs:
       game-binary-name: The Mirror Dev.exe
       bucket-name: no-bucket
       os: "windows-latest"
-  build-macos-client:
-    name: 🍎 Build MacOS Dev PR
-    uses: ./.github/workflows/client-build-tool.yml
-    needs: build-macos
-    secrets:
-      gcp-secret: ""
-      cicd-token-github: ${{ secrets.GITHUB_TOKEN }}
-    with:
-      should-deploy: false
-      should-run-unit-tests: true
-      should-notify-on-failure: false
-      should-unzip-editor: true
-      should-install-timeout-macos: true
-      editor-binary-workflow: deployment.yml
-      editor-binary-download: MirrorGodotEditorMac.app.zip
-      editor-binary-name: MirrorGodotEditorMac.app/Contents/MacOS/Godot
-      editor-binary-branch: themirror
-      editor-template-directory: ~/Library/Application\ Support/Godot/export_templates/4.3.dev
-      template-binary-workflow: deployment.yml
-      template-binary-name: macos_template.app.zip
-      template-binary-branch: dev
-      export-template-file: macos.zip
-      game-environment-cfg-name: official
-      game-export-preset: MacOS-themirror-dev
-      game-binary-name: The Mirror Dev.app
-      bucket-name: no-bucket
-      os: "macos-latest"
-  build-linux-client:
-    name: 🐧 Build Linux Dev PR
-    uses: ./.github/workflows/client-build-tool.yml
-    needs: build-linux
-    secrets:
-      gcp-secret: ""
-      cicd-token-github: ${{ secrets.GITHUB_TOKEN }}
-    with:
-      should-deploy: false
-      should-run-unit-tests: true
-      should-notify-on-failure: false
-      editor-binary-workflow: deployment.yml
-      editor-binary-name: MirrorGodotEditorLinux.x86_64
-      editor-binary-download: MirrorGodotEditorLinux.x86_64
-      editor-binary-branch: dev
-      editor-template-directory: ~/.local/share/godot/export_templates/4.3.dev
-      template-binary-workflow: deployment.yml
-      template-binary-name: linux_release.x86_64
-      template-binary-branch: themirror
-      export-template-file: linux_release.x86_64
-      game-environment-cfg-name: official
-      game-export-preset: Linux
-      game-binary-name: The Mirror Dev.x86_64
-      bucket-name: no-bucket
-      os: "ubuntu-20.04"
+      editor-download-url: https://storage.googleapis.com/mirror_native_client_builds/Engine/${{needs.get-or-build-engine.outputs.commit_hash}}/MirrorGodotEditorWindows.exe
+      template-download-url: https://storage.googleapis.com/mirror_native_client_builds/Engine/${{needs.get-or-build-engine.outputs.commit_hash}}/windows_release_x86_64.exe
+  # build-macos-client:
+  #   name: 🍎 Build MacOS Dev PR
+  #   uses: ./.github/workflows/client-build-tool.yml
+  #   needs: get-or-build-engine
+  #   secrets:
+  #     gcp-secret: ""
+  #     cicd-token-github: ${{ secrets.GITHUB_TOKEN }}
+  #   with:
+  #     should-deploy: false
+  #     should-run-unit-tests: true
+  #     should-notify-on-failure: false
+  #     should-unzip-editor: true
+  #     should-install-timeout-macos: true
+  #     editor-binary-workflow: deployment.yml
+  #     editor-binary-download: MirrorGodotEditorMac.app.zip
+  #     editor-binary-name: MirrorGodotEditorMac.app/Contents/MacOS/Godot
+  #     editor-binary-branch: themirror
+  #     editor-template-directory: ~/Library/Application\ Support/Godot/export_templates/4.3.dev
+  #     template-binary-workflow: deployment.yml
+  #     template-binary-name: macos_template.app.zip
+  #     template-binary-branch: dev
+  #     export-template-file: macos.zip
+  #     game-environment-cfg-name: official
+  #     game-export-preset: MacOS-themirror-dev
+  #     game-binary-name: The Mirror Dev.app
+  #     bucket-name: no-bucket
+  #     os: "macos-latest"
+  # build-linux-client:
+  #   name: 🐧 Build Linux Dev PR
+  #   uses: ./.github/workflows/client-build-tool.yml
+  #   needs: get-or-build-engine
+  #   secrets:
+  #     gcp-secret: ""
+  #     cicd-token-github: ${{ secrets.GITHUB_TOKEN }}
+  #   with:
+  #     should-deploy: false
+  #     should-run-unit-tests: true
+  #     should-notify-on-failure: false
+  #     editor-binary-workflow: deployment.yml
+  #     editor-binary-name: MirrorGodotEditorLinux.x86_64
+  #     editor-binary-download: MirrorGodotEditorLinux.x86_64
+  #     editor-binary-branch: dev
+  #     editor-template-directory: ~/.local/share/godot/export_templates/4.3.dev
+  #     template-binary-workflow: deployment.yml
+  #     template-binary-name: linux_release.x86_64
+  #     template-binary-branch: themirror
+  #     export-template-file: linux_release.x86_64
+  #     game-environment-cfg-name: official
+  #     game-export-preset: Linux
+  #     game-binary-name: The Mirror Dev.x86_64
+  #     bucket-name: no-bucket
+  #     os: "ubuntu-20.04"
 

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -21,6 +21,8 @@ jobs:
     uses: ./.github/workflows/engine.yml
     secrets:
       GCP_BUCKET_UPLOAD: ${{ secrets.GCP_BUCKET_UPLOAD }}
+    with:
+      environment: "dev"
 
   build-windows-client:
     name: 🏁 Build Windows Dev PR

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -29,7 +29,7 @@ jobs:
     uses: ./.github/workflows/client-build-tool.yml
     needs: get-or-build-engine
     secrets:
-      gcp-secret: ""
+      gcp-secret: ${{ secrets.GCP_BUCKET_UPLOAD }}
       cicd-token-github: ${{ secrets.GITHUB_TOKEN }}
     with:
       should-deploy: false
@@ -51,56 +51,58 @@ jobs:
       os: "windows-latest"
       editor-download-url: https://storage.googleapis.com/mirror_native_client_builds/Engine/${{needs.get-or-build-engine.outputs.commit_hash}}/MirrorGodotEditorWindows.exe
       template-download-url: https://storage.googleapis.com/mirror_native_client_builds/Engine/${{needs.get-or-build-engine.outputs.commit_hash}}/windows_release_x86_64.exe
-  # build-macos-client:
-  #   name: 🍎 Build MacOS Dev PR
-  #   uses: ./.github/workflows/client-build-tool.yml
-  #   needs: get-or-build-engine
-  #   secrets:
-  #     gcp-secret: ""
-  #     cicd-token-github: ${{ secrets.GITHUB_TOKEN }}
-  #   with:
-  #     should-deploy: false
-  #     should-run-unit-tests: true
-  #     should-notify-on-failure: false
-  #     should-unzip-editor: true
-  #     should-install-timeout-macos: true
-  #     editor-binary-workflow: deployment.yml
-  #     editor-binary-download: MirrorGodotEditorMac.app.zip
-  #     editor-binary-name: MirrorGodotEditorMac.app/Contents/MacOS/Godot
-  #     editor-binary-branch: themirror
-  #     editor-template-directory: ~/Library/Application\ Support/Godot/export_templates/4.3.dev
-  #     template-binary-workflow: deployment.yml
-  #     template-binary-name: macos_template.app.zip
-  #     template-binary-branch: dev
-  #     export-template-file: macos.zip
-  #     game-environment-cfg-name: official
-  #     game-export-preset: MacOS-themirror-dev
-  #     game-binary-name: The Mirror Dev.app
-  #     bucket-name: no-bucket
-  #     os: "macos-latest"
-  # build-linux-client:
-  #   name: 🐧 Build Linux Dev PR
-  #   uses: ./.github/workflows/client-build-tool.yml
-  #   needs: get-or-build-engine
-  #   secrets:
-  #     gcp-secret: ""
-  #     cicd-token-github: ${{ secrets.GITHUB_TOKEN }}
-  #   with:
-  #     should-deploy: false
-  #     should-run-unit-tests: true
-  #     should-notify-on-failure: false
-  #     editor-binary-workflow: deployment.yml
-  #     editor-binary-name: MirrorGodotEditorLinux.x86_64
-  #     editor-binary-download: MirrorGodotEditorLinux.x86_64
-  #     editor-binary-branch: dev
-  #     editor-template-directory: ~/.local/share/godot/export_templates/4.3.dev
-  #     template-binary-workflow: deployment.yml
-  #     template-binary-name: linux_release.x86_64
-  #     template-binary-branch: themirror
-  #     export-template-file: linux_release.x86_64
-  #     game-environment-cfg-name: official
-  #     game-export-preset: Linux
-  #     game-binary-name: The Mirror Dev.x86_64
-  #     bucket-name: no-bucket
-  #     os: "ubuntu-20.04"
-
+  build-macos-client:
+    name: 🍎 Build MacOS Dev PR
+    uses: ./.github/workflows/client-build-tool.yml
+    needs: get-or-build-engine
+    secrets:
+      gcp-secret: ""
+      cicd-token-github: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      should-deploy: false
+      should-run-unit-tests: true
+      should-notify-on-failure: false
+      should-unzip-editor: true
+      should-install-timeout-macos: true
+      editor-binary-workflow: deployment.yml
+      editor-binary-download: MirrorGodotEditorMac.app.zip
+      editor-binary-name: MirrorGodotEditorMac.app/Contents/MacOS/Godot
+      editor-binary-branch: themirror
+      editor-template-directory: ~/Library/Application\ Support/Godot/export_templates/4.3.dev
+      template-binary-workflow: deployment.yml
+      template-binary-name: macos_template.app.zip
+      template-binary-branch: dev
+      export-template-file: macos.zip
+      game-environment-cfg-name: official
+      game-export-preset: MacOS-themirror-dev
+      game-binary-name: The Mirror Dev.app
+      bucket-name: no-bucket
+      os: "macos-latest"
+      editor-download-url: https://storage.googleapis.com/mirror_native_client_builds/Engine/${{needs.get-or-build-engine.outputs.commit_hash}}/MirrorGodotEditorMac.app.zip
+      template-download-url: https://storage.googleapis.com/mirror_native_client_builds/Engine/${{needs.get-or-build-engine.outputs.commit_hash}}/macos_template.app.zip
+    name: 🐧 Build Linux Dev PR
+    uses: ./.github/workflows/client-build-tool.yml
+    needs: get-or-build-engine
+    secrets:
+      gcp-secret: ""
+      cicd-token-github: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      should-deploy: false
+      should-run-unit-tests: true
+      should-notify-on-failure: false
+      editor-binary-workflow: deployment.yml
+      editor-binary-name: MirrorGodotEditorLinux.x86_64
+      editor-binary-download: MirrorGodotEditorLinux.x86_64
+      editor-binary-branch: dev
+      editor-template-directory: ~/.local/share/godot/export_templates/4.3.dev
+      template-binary-workflow: deployment.yml
+      template-binary-name: linux_release.x86_64
+      template-binary-branch: themirror
+      export-template-file: linux_release.x86_64
+      game-environment-cfg-name: official
+      game-export-preset: Linux
+      game-binary-name: The Mirror Dev.x86_64
+      bucket-name: no-bucket
+      os: "ubuntu-20.04"
+      editor-download-url: https://storage.googleapis.com/mirror_native_client_builds/Engine/${{needs.get-or-build-engine.outputs.commit_hash}}/MirrorGodotEditorLinux.x86_64
+      template-download-url: https://storage.googleapis.com/mirror_native_client_builds/Engine/${{needs.get-or-build-engine.outputs.commit_hash}}/linux_release.x86_64

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -80,6 +80,7 @@ jobs:
       os: "macos-latest"
       editor-download-url: https://storage.googleapis.com/mirror_native_client_builds/Engine/${{needs.get-or-build-engine.outputs.commit_hash}}/MirrorGodotEditorMac.app.zip
       template-download-url: https://storage.googleapis.com/mirror_native_client_builds/Engine/${{needs.get-or-build-engine.outputs.commit_hash}}/macos_template.app.zip
+  build-linux-client:
     name: 🐧 Build Linux Dev PR
     uses: ./.github/workflows/client-build-tool.yml
     needs: get-or-build-engine

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -18,13 +18,9 @@ concurrency:
 jobs:
   get-or-build-engine:
     name: Building Engine
-    runs-on: "ubuntu-20.04"
-    steps:
-      - uses: actions/checkout@v4
-      - name: build engine
-        uses: ./.github/workflows/engine.yml
-        with:
-          cicd-token-github: ${{ secrets.GCP_BUCKET_UPLOAD }}
+    uses: ./.github/workflows/engine.yml
+    secrets:
+      cicd-token-github: ${{ secrets.GCP_BUCKET_UPLOAD }}
 
   build-windows-client:
     name: 🏁 Build Windows Dev PR

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -20,7 +20,7 @@ jobs:
     name: Building Engine
     uses: ./.github/workflows/engine.yml
     secrets:
-      cicd-token-github: ${{ secrets.GCP_BUCKET_UPLOAD }}
+      GCP_BUCKET_UPLOAD: ${{ secrets.GCP_BUCKET_UPLOAD }}
 
   build-windows-client:
     name: 🏁 Build Windows Dev PR

--- a/.github/workflows/engine.yml
+++ b/.github/workflows/engine.yml
@@ -378,5 +378,5 @@ jobs:
       - name: Upload binary
         uses: 'google-github-actions/upload-cloud-storage@v2'
         with:
-          path: ./godot-engine/bin/${{ matrix.artifact-name }}.zip
+          path: ./godot-engine/bin/${{ matrix.artifact-name }}
           destination: ${{ matrix.bucket-name }}/${{steps.vars.outputs.sha_short}}/

--- a/.github/workflows/engine.yml
+++ b/.github/workflows/engine.yml
@@ -62,7 +62,7 @@ jobs:
             artifact: true
             bucket-name: mirror_native_client_builds/Engine
     outputs:
-      commit_hash: ${{ steps.vars.outputs.vars }}
+      commit_hash: ${{ steps.vars.outputs.sha_short }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/engine.yml
+++ b/.github/workflows/engine.yml
@@ -1,0 +1,324 @@
+name: Engine
+on:
+    workflow_call:
+      secrets:
+        GCP_BUCKET_UPLOAD:
+          required: true
+      outputs:
+        commit_hash:
+          value: ${{ jobs.build-windows.outputs.commit_hash }}
+
+defaults:
+  run:
+    working-directory: ./godot-engine
+
+# Global Settings
+env:
+  # Used for the cache key. Add version suffix to force clean build.
+  GODOT_BASE_BRANCH: master
+  SCONSFLAGS: verbose=yes warnings=extra werror=no module_text_server_fb_enabled=yes fontconfig=no
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  TSAN_OPTIONS: suppressions=misc/error_suppressions/tsan.txt
+
+concurrency:
+  # workflow name - PR || fallback to unique run id, this happens when you're not building a PR
+  # this ensures all branches build properly and cancel their previous runs
+  group: engine-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-windows:
+    runs-on: "windows-latest"
+    name: ${{ matrix.name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Windows Editor
+            cache-name: windows-editor
+            target: editor
+            strip: true
+            tests: false
+            sconsflags: arch=x86_64 debug_symbols=no windows_subsystem=console optimize=speed production=yes
+            bin: "./bin/godot.windows.editor.x86_64"
+            artifact-name: "MirrorGodotEditorWindows"
+            artifact: true
+            bucket-name: mirror_native_client_builds/Engine
+
+          - name: Windows Template
+            cache-name: windows-template
+            target: template_debug
+            strip: true
+            tests: false
+            sconsflags: arch=x86_64 debug_symbols=no optimize=speed
+            bin: "./bin/godot.windows.template_debug.x86_64"
+            artifact-name: "windows_release_x86_64"
+            artifact: true
+            bucket-name: mirror_native_client_builds/Engine
+    outputs:
+      commit_hash: ${{ steps.vars.outputs.vars }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      
+      - name: Get short commit hash
+        id: vars
+        run: echo "sha_short=$(git rev-parse --short=8 HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Setup Godot build cache
+        uses: ./godot-engine/.github/actions/godot-cache
+        with:
+          cache-name: ${{ matrix.cache-name }}
+        continue-on-error: true
+
+      - name: Setup python and scons
+        uses: ./godot-engine/.github/actions/godot-deps
+
+      #- name: Download Direct3D 12 SDK components
+      #  run: python ./misc/scripts/install_d3d12_sdk_windows.py
+
+      - name: Setup MSVC problem matcher
+        uses: ammaraskar/msvc-problem-matcher@master
+
+      - name: Compilation
+        uses: ./.github/actions/godot-build
+        with:
+          sconsflags: ${{ env.SCONSFLAGS }} ${{ matrix.sconsflags }}
+          platform: windows
+          target: ${{ matrix.target }}
+          tests: ${{ matrix.tests }}
+
+      - name: Strip binaries
+        if: ${{ matrix.strip }}
+        run: |
+          Remove-Item bin/* -Include *.exp,*.lib,*.pdb -Force
+
+      - name: Move PDB file (if not stripped)
+        if: ${{ !matrix.strip }}
+        run: |
+          dir -Path ./bin/
+          mv ${{matrix.bin}}.pdb bin/${{ matrix.artifact-name}}.pdb
+
+      - name: Prepare artifact
+        if: ${{ matrix.artifact }}
+        run: |
+          mv ${{ matrix.bin }}.exe bin/${{ matrix.artifact-name }}.exe
+
+      - name: Upload artifact
+        uses: ./.github/actions/upload-artifact
+        if: ${{ matrix.artifact }}
+        with:
+          path: ./godot-engine/bin/${{ matrix.artifact-name }}.exe
+          name: ${{ matrix.artifact-name }}.exe
+
+      - name: Google Cloud Platform authentication
+        uses: 'google-github-actions/auth@v2'
+        with:
+          credentials_json: '${{ secrets.GCP_BUCKET_UPLOAD }}'
+
+      - name: Upload binary
+        uses: 'google-github-actions/upload-cloud-storage@v2'
+        with:
+          path: bin/${{ matrix.artifact-name }}
+          destination: ${{ matrix.bucket-name }}/${{steps.vars.outputs.sha_short}}/
+  build-macos:
+    runs-on: "macos-latest"
+    name: ${{ matrix.name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: MacOS Editor
+            cache-name: macos-editor
+            target: editor
+            tests: false
+            strip: true
+            sconsflags: debug_symbols=no optimize=speed production=yes
+            dist-app: "macos_tools.app"
+            packaged-app: "MirrorGodotEditorMac.app"
+            bin-name: "godot.macos.editor.universal"
+            bin-name-x86_64: "godot.macos.editor.x86_64"
+            bin-name-arm64: "godot.macos.editor.arm64"
+            artifact-bin-name: "Godot"
+            artifact-name: "MirrorGodotEditorMac.app"
+
+          - name: MacOS Template
+            cache-name: macos-template
+            target: template_debug
+            tests: false
+            strip: true
+            sconsflags: debug_symbols=no optimize=speed
+            dist-app: "macos_template.app"
+            packaged-app: "macos_template.app"
+            bin-name: "godot.macos.template_debug.universal"
+            bin-name-x86_64: "godot.macos.template_debug.x86_64"
+            bin-name-arm64: "godot.macos.template_debug.arm64"
+            artifact-bin-name: "godot_macos_release.universal"
+            artifact-name: "macos_template.app"
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Setup python and scons
+        uses: ./godot-engine/.github/actions/godot-deps
+      - name: Setup Vulkan SDK
+        run: |
+          # Download and install the Vulkan SDK.
+          curl -L "https://sdk.lunarg.com/sdk/download/latest/mac/vulkan-sdk.dmg" -o /tmp/vulkan-sdk.dmg
+          hdiutil attach /tmp/vulkan-sdk.dmg -mountpoint /Volumes/vulkan-sdk
+          /Volumes/vulkan-sdk/InstallVulkan.app/Contents/MacOS/InstallVulkan \
+              --accept-licenses --default-answer --confirm-command install
+
+      - name: Setup Godot build cache
+        uses: ./godot-engine/.github/actions/godot-cache
+        with:
+          cache-name: ${{ matrix.cache-name }}
+        continue-on-error: true
+
+      - name: Setup scons (python is already installed on self-hosted runners!)
+        shell: bash
+        run: |
+          python3 -c "import sys; print(sys.version)"
+          python3 -m ensurepip --upgrade
+          python3 -m pip install --user scons
+          scons --version
+
+      - name: Setup cmake
+        shell: bash
+        run: |
+          brew install cmake
+          cmake --version
+
+      - name: Remove existing binaries
+        run: |
+          rm -Rf bin/
+
+      - name: Compilation (x86_64)
+        uses: ./.github/actions/godot-build
+        with:
+          sconsflags: ${{ env.SCONSFLAGS }} arch=x86_64
+          platform: macos
+          target: ${{ matrix.target }}
+          tests: ${{ matrix.tests }}
+
+      - name: Compilation (arm64)
+        uses: ./.github/actions/godot-build
+        with:
+          sconsflags: ${{ env.SCONSFLAGS }} arch=arm64
+          platform: macos
+          target: ${{ matrix.target }}
+          tests: ${{ matrix.tests }}
+
+      - name: Strip binaries
+        if: ${{ matrix.strip }}
+        run: |
+          echo "Stripping binaries"
+          strip bin/*
+
+      - name: Prepare universal executable
+        run: |
+          lipo -create bin/${{ matrix.bin-name-x86_64 }} bin/${{ matrix.bin-name-arm64 }} -output bin/${{ matrix.bin-name }}
+          chmod -R +x bin/*
+
+      - name: Package in macOS app bundle
+        shell: sh
+        run: |
+          cp -R misc/dist/${{ matrix.dist-app }} bin/${{ matrix.packaged-app }}
+          cd bin/
+          mkdir -p ${{ matrix.packaged-app }}/Contents/MacOS
+          cp ${{ matrix.bin-name }} ${{ matrix.packaged-app }}/Contents/MacOS/${{ matrix.artifact-bin-name }}
+          chmod -R +x ${{ matrix.packaged-app }}
+          xattr -rc ${{ matrix.packaged-app }}
+          zip -q -9 -r ${{ matrix.artifact-name }}.zip ${{ matrix.packaged-app }}
+
+      - name: Upload artifact
+        uses: ./.github/actions/upload-artifact
+        with:
+          name: "${{ matrix.artifact-name }}.zip"
+          path: "./godot-engine/bin/${{ matrix.artifact-name }}.zip"
+  build-linux:
+    runs-on: "ubuntu-20.04" # MUST run on the old version for GLIBC compatibility
+    name: ${{ matrix.name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux Editor
+            cache-name: linux-editor
+            target: editor
+            sconsflags: arch=x86_64 debug_symbols=no optimize=speed production=yes
+            strip: false
+            bin: "./bin/godot.linuxbsd.editor.x86_64"
+            artifact-name: "MirrorGodotEditorLinux.x86_64"
+            artifact: true
+            tests: no
+
+          - name: Linux Template
+            cache-name: linux-template
+            target: template_debug
+            strip: true
+            sconsflags: arch=x86_64 debug_symbols=no optimize=speed
+            bin: "./bin/godot.linuxbsd.template_debug.x86_64"
+            artifact-name: "linux_release.x86_64"
+            artifact: true
+            tests: no
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Godot build cache
+        uses: ./godot-engine/.github/actions/godot-cache
+        with:
+          cache-name: ${{ matrix.cache-name }}
+        continue-on-error: true
+
+      - name: Setup scons
+        shell: bash
+        run: |
+          python -c "import sys; print(sys.version)"
+          python -m pip install scons==4.4.0
+          scons --version
+
+      - name: Setup GCC problem matcher
+        uses: ammaraskar/gcc-problem-matcher@master
+
+      - name: Compilation
+        uses: ./.github/actions/godot-build
+        with:
+          sconsflags: ${{ env.SCONSFLAGS }} ${{ matrix.sconsflags }}
+          platform: linuxbsd
+          target: ${{ matrix.target }}
+          tests: ${{ matrix.tests }}
+
+      - name: Strip binaries
+        if: ${{ matrix.strip }}
+        run: |
+          strip bin/godot.*
+
+      # - name: Shrink debug symbols
+      #   if: ${{ !matrix.strip }}
+      #   run: |
+      #     # remove duplicate symbols from binary
+      #     dwz ${{ matrix.bin }} -L none -o Middleman.debug
+      #     # make the debug symbols compressed
+      #     objcopy --compress-debug-sections Middleman.debug FinalMan.debug
+      #     # overwrite the original file
+      #     mv FinalMan.debug ${{ matrix.bin }}
+
+      - name: Prepare artifact
+        if: ${{ matrix.artifact }}
+        run: |
+          chmod +x bin/godot.*
+          mv ${{ matrix.bin }} bin/${{ matrix.artifact-name }}
+
+      - name: Upload artifact
+        uses: ./.github/actions/upload-artifact
+        if: ${{ matrix.artifact }}
+        with:
+          path: ./godot-engine/bin/${{ matrix.artifact-name }}
+          name: ${{ matrix.artifact-name }}

--- a/.github/workflows/engine.yml
+++ b/.github/workflows/engine.yml
@@ -15,7 +15,6 @@ on:
 defaults:
   run:
     working-directory: ./godot-engine
-    shell: bash
 
 # Global Settings
 env:
@@ -73,8 +72,7 @@ jobs:
         id: vars
         run: |
           echo "Git hash: $(git rev-parse --short=8 HEAD)"
-          echo "sha_short=$(git rev-parse --short=8 HEAD)" >> $GITHUB_OUTPUT
-
+          echo "sha_short=$(git rev-parse --short=8 HEAD)" >> $Env:GITHUB_OUTPUT
 
       - name: Test Hash exists
         run: echo "Test value is ${{steps.vars.outputs.sha_short}}"

--- a/.github/workflows/engine.yml
+++ b/.github/workflows/engine.yml
@@ -67,10 +67,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      
+
       - name: Get short commit hash
         id: vars
-        run: echo "sha_short=$(git rev-parse --short=8 HEAD)" >> $GITHUB_OUTPUT
+        run: |
+          echo "Git hash: $(git rev-parse --short=8 HEAD)"
+          echo "sha_short=$(git rev-parse --short=8 HEAD)" >> $GITHUB_OUTPUT
 
       - name: Test Hash exists
         run: echo "Test value is ${{steps.vars.outputs.sha_short}}"

--- a/.github/workflows/engine.yml
+++ b/.github/workflows/engine.yml
@@ -72,6 +72,9 @@ jobs:
         id: vars
         run: echo "sha_short=$(git rev-parse --short=8 HEAD)" >> $GITHUB_OUTPUT
 
+      - name: Test Hash exists
+        run: echo "Test value is ${{steps.vars.outputs.sha_short}}"
+
       - name: Setup Godot build cache
         uses: ./godot-engine/.github/actions/godot-cache
         with:

--- a/.github/workflows/engine.yml
+++ b/.github/workflows/engine.yml
@@ -132,202 +132,202 @@ jobs:
         with:
           path: ./godot-engine/bin/${{ matrix.artifact-name }}.exe
           destination: ${{ matrix.bucket-name }}/${{steps.vars.outputs.sha_short}}/
-  build-macos:
-    runs-on: "macos-latest"
-    name: ${{ matrix.name }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: MacOS Editor
-            cache-name: macos-editor
-            target: editor
-            tests: false
-            strip: true
-            sconsflags: debug_symbols=no optimize=speed production=yes
-            dist-app: "macos_tools.app"
-            packaged-app: "MirrorGodotEditorMac.app"
-            bin-name: "godot.macos.editor.universal"
-            bin-name-x86_64: "godot.macos.editor.x86_64"
-            bin-name-arm64: "godot.macos.editor.arm64"
-            artifact-bin-name: "Godot"
-            artifact-name: "MirrorGodotEditorMac.app"
+  # build-macos:
+  #   runs-on: "macos-latest"
+  #   name: ${{ matrix.name }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       include:
+  #         - name: MacOS Editor
+  #           cache-name: macos-editor
+  #           target: editor
+  #           tests: false
+  #           strip: true
+  #           sconsflags: debug_symbols=no optimize=speed production=yes
+  #           dist-app: "macos_tools.app"
+  #           packaged-app: "MirrorGodotEditorMac.app"
+  #           bin-name: "godot.macos.editor.universal"
+  #           bin-name-x86_64: "godot.macos.editor.x86_64"
+  #           bin-name-arm64: "godot.macos.editor.arm64"
+  #           artifact-bin-name: "Godot"
+  #           artifact-name: "MirrorGodotEditorMac.app"
 
-          - name: MacOS Template
-            cache-name: macos-template
-            target: template_debug
-            tests: false
-            strip: true
-            sconsflags: debug_symbols=no optimize=speed
-            dist-app: "macos_template.app"
-            packaged-app: "macos_template.app"
-            bin-name: "godot.macos.template_debug.universal"
-            bin-name-x86_64: "godot.macos.template_debug.x86_64"
-            bin-name-arm64: "godot.macos.template_debug.arm64"
-            artifact-bin-name: "godot_macos_release.universal"
-            artifact-name: "macos_template.app"
+  #         - name: MacOS Template
+  #           cache-name: macos-template
+  #           target: template_debug
+  #           tests: false
+  #           strip: true
+  #           sconsflags: debug_symbols=no optimize=speed
+  #           dist-app: "macos_template.app"
+  #           packaged-app: "macos_template.app"
+  #           bin-name: "godot.macos.template_debug.universal"
+  #           bin-name-x86_64: "godot.macos.template_debug.x86_64"
+  #           bin-name-arm64: "godot.macos.template_debug.arm64"
+  #           artifact-bin-name: "godot_macos_release.universal"
+  #           artifact-name: "macos_template.app"
 
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - name: Setup python and scons
-        uses: ./godot-engine/.github/actions/godot-deps
-      - name: Setup Vulkan SDK
-        run: |
-          # Download and install the Vulkan SDK.
-          curl -L "https://sdk.lunarg.com/sdk/download/latest/mac/vulkan-sdk.dmg" -o /tmp/vulkan-sdk.dmg
-          hdiutil attach /tmp/vulkan-sdk.dmg -mountpoint /Volumes/vulkan-sdk
-          /Volumes/vulkan-sdk/InstallVulkan.app/Contents/MacOS/InstallVulkan \
-              --accept-licenses --default-answer --confirm-command install
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         submodules: recursive
+  #     - name: Setup python and scons
+  #       uses: ./godot-engine/.github/actions/godot-deps
+  #     - name: Setup Vulkan SDK
+  #       run: |
+  #         # Download and install the Vulkan SDK.
+  #         curl -L "https://sdk.lunarg.com/sdk/download/latest/mac/vulkan-sdk.dmg" -o /tmp/vulkan-sdk.dmg
+  #         hdiutil attach /tmp/vulkan-sdk.dmg -mountpoint /Volumes/vulkan-sdk
+  #         /Volumes/vulkan-sdk/InstallVulkan.app/Contents/MacOS/InstallVulkan \
+  #             --accept-licenses --default-answer --confirm-command install
 
-      - name: Setup Godot build cache
-        uses: ./godot-engine/.github/actions/godot-cache
-        with:
-          cache-name: ${{ matrix.cache-name }}
-        continue-on-error: true
+  #     - name: Setup Godot build cache
+  #       uses: ./godot-engine/.github/actions/godot-cache
+  #       with:
+  #         cache-name: ${{ matrix.cache-name }}
+  #       continue-on-error: true
 
-      - name: Setup scons (python is already installed on self-hosted runners!)
-        shell: bash
-        run: |
-          python3 -c "import sys; print(sys.version)"
-          python3 -m ensurepip --upgrade
-          python3 -m pip install --user scons
-          scons --version
+  #     - name: Setup scons (python is already installed on self-hosted runners!)
+  #       shell: bash
+  #       run: |
+  #         python3 -c "import sys; print(sys.version)"
+  #         python3 -m ensurepip --upgrade
+  #         python3 -m pip install --user scons
+  #         scons --version
 
-      - name: Setup cmake
-        shell: bash
-        run: |
-          brew install cmake
-          cmake --version
+  #     - name: Setup cmake
+  #       shell: bash
+  #       run: |
+  #         brew install cmake
+  #         cmake --version
 
-      - name: Remove existing binaries
-        run: |
-          rm -Rf bin/
+  #     - name: Remove existing binaries
+  #       run: |
+  #         rm -Rf bin/
 
-      - name: Compilation (x86_64)
-        uses: ./.github/actions/godot-build
-        with:
-          sconsflags: ${{ env.SCONSFLAGS }} arch=x86_64
-          platform: macos
-          target: ${{ matrix.target }}
-          tests: ${{ matrix.tests }}
+  #     - name: Compilation (x86_64)
+  #       uses: ./.github/actions/godot-build
+  #       with:
+  #         sconsflags: ${{ env.SCONSFLAGS }} arch=x86_64
+  #         platform: macos
+  #         target: ${{ matrix.target }}
+  #         tests: ${{ matrix.tests }}
 
-      - name: Compilation (arm64)
-        uses: ./.github/actions/godot-build
-        with:
-          sconsflags: ${{ env.SCONSFLAGS }} arch=arm64
-          platform: macos
-          target: ${{ matrix.target }}
-          tests: ${{ matrix.tests }}
+  #     - name: Compilation (arm64)
+  #       uses: ./.github/actions/godot-build
+  #       with:
+  #         sconsflags: ${{ env.SCONSFLAGS }} arch=arm64
+  #         platform: macos
+  #         target: ${{ matrix.target }}
+  #         tests: ${{ matrix.tests }}
 
-      - name: Strip binaries
-        if: ${{ matrix.strip }}
-        run: |
-          echo "Stripping binaries"
-          strip bin/*
+  #     - name: Strip binaries
+  #       if: ${{ matrix.strip }}
+  #       run: |
+  #         echo "Stripping binaries"
+  #         strip bin/*
 
-      - name: Prepare universal executable
-        run: |
-          lipo -create bin/${{ matrix.bin-name-x86_64 }} bin/${{ matrix.bin-name-arm64 }} -output bin/${{ matrix.bin-name }}
-          chmod -R +x bin/*
+  #     - name: Prepare universal executable
+  #       run: |
+  #         lipo -create bin/${{ matrix.bin-name-x86_64 }} bin/${{ matrix.bin-name-arm64 }} -output bin/${{ matrix.bin-name }}
+  #         chmod -R +x bin/*
 
-      - name: Package in macOS app bundle
-        shell: sh
-        run: |
-          cp -R misc/dist/${{ matrix.dist-app }} bin/${{ matrix.packaged-app }}
-          cd bin/
-          mkdir -p ${{ matrix.packaged-app }}/Contents/MacOS
-          cp ${{ matrix.bin-name }} ${{ matrix.packaged-app }}/Contents/MacOS/${{ matrix.artifact-bin-name }}
-          chmod -R +x ${{ matrix.packaged-app }}
-          xattr -rc ${{ matrix.packaged-app }}
-          zip -q -9 -r ${{ matrix.artifact-name }}.zip ${{ matrix.packaged-app }}
+  #     - name: Package in macOS app bundle
+  #       shell: sh
+  #       run: |
+  #         cp -R misc/dist/${{ matrix.dist-app }} bin/${{ matrix.packaged-app }}
+  #         cd bin/
+  #         mkdir -p ${{ matrix.packaged-app }}/Contents/MacOS
+  #         cp ${{ matrix.bin-name }} ${{ matrix.packaged-app }}/Contents/MacOS/${{ matrix.artifact-bin-name }}
+  #         chmod -R +x ${{ matrix.packaged-app }}
+  #         xattr -rc ${{ matrix.packaged-app }}
+  #         zip -q -9 -r ${{ matrix.artifact-name }}.zip ${{ matrix.packaged-app }}
 
-      - name: Upload artifact
-        uses: ./.github/actions/upload-artifact
-        with:
-          name: "${{ matrix.artifact-name }}.zip"
-          path: "./godot-engine/bin/${{ matrix.artifact-name }}.zip"
-  build-linux:
-    runs-on: "ubuntu-20.04" # MUST run on the old version for GLIBC compatibility
-    name: ${{ matrix.name }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: Linux Editor
-            cache-name: linux-editor
-            target: editor
-            sconsflags: arch=x86_64 debug_symbols=no optimize=speed production=yes
-            strip: false
-            bin: "./bin/godot.linuxbsd.editor.x86_64"
-            artifact-name: "MirrorGodotEditorLinux.x86_64"
-            artifact: true
-            tests: no
+  #     - name: Upload artifact
+  #       uses: ./.github/actions/upload-artifact
+  #       with:
+  #         name: "${{ matrix.artifact-name }}.zip"
+  #         path: "./godot-engine/bin/${{ matrix.artifact-name }}.zip"
+  # build-linux:
+  #   runs-on: "ubuntu-20.04" # MUST run on the old version for GLIBC compatibility
+  #   name: ${{ matrix.name }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       include:
+  #         - name: Linux Editor
+  #           cache-name: linux-editor
+  #           target: editor
+  #           sconsflags: arch=x86_64 debug_symbols=no optimize=speed production=yes
+  #           strip: false
+  #           bin: "./bin/godot.linuxbsd.editor.x86_64"
+  #           artifact-name: "MirrorGodotEditorLinux.x86_64"
+  #           artifact: true
+  #           tests: no
 
-          - name: Linux Template
-            cache-name: linux-template
-            target: template_debug
-            strip: true
-            sconsflags: arch=x86_64 debug_symbols=no optimize=speed
-            bin: "./bin/godot.linuxbsd.template_debug.x86_64"
-            artifact-name: "linux_release.x86_64"
-            artifact: true
-            tests: no
+  #         - name: Linux Template
+  #           cache-name: linux-template
+  #           target: template_debug
+  #           strip: true
+  #           sconsflags: arch=x86_64 debug_symbols=no optimize=speed
+  #           bin: "./bin/godot.linuxbsd.template_debug.x86_64"
+  #           artifact-name: "linux_release.x86_64"
+  #           artifact: true
+  #           tests: no
 
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         submodules: recursive
 
-      - name: Setup Godot build cache
-        uses: ./godot-engine/.github/actions/godot-cache
-        with:
-          cache-name: ${{ matrix.cache-name }}
-        continue-on-error: true
+  #     - name: Setup Godot build cache
+  #       uses: ./godot-engine/.github/actions/godot-cache
+  #       with:
+  #         cache-name: ${{ matrix.cache-name }}
+  #       continue-on-error: true
 
-      - name: Setup scons
-        shell: bash
-        run: |
-          python -c "import sys; print(sys.version)"
-          python -m pip install scons==4.4.0
-          scons --version
+  #     - name: Setup scons
+  #       shell: bash
+  #       run: |
+  #         python -c "import sys; print(sys.version)"
+  #         python -m pip install scons==4.4.0
+  #         scons --version
 
-      - name: Setup GCC problem matcher
-        uses: ammaraskar/gcc-problem-matcher@master
+  #     - name: Setup GCC problem matcher
+  #       uses: ammaraskar/gcc-problem-matcher@master
 
-      - name: Compilation
-        uses: ./.github/actions/godot-build
-        with:
-          sconsflags: ${{ env.SCONSFLAGS }} ${{ matrix.sconsflags }}
-          platform: linuxbsd
-          target: ${{ matrix.target }}
-          tests: ${{ matrix.tests }}
+  #     - name: Compilation
+  #       uses: ./.github/actions/godot-build
+  #       with:
+  #         sconsflags: ${{ env.SCONSFLAGS }} ${{ matrix.sconsflags }}
+  #         platform: linuxbsd
+  #         target: ${{ matrix.target }}
+  #         tests: ${{ matrix.tests }}
 
-      - name: Strip binaries
-        if: ${{ matrix.strip }}
-        run: |
-          strip bin/godot.*
+  #     - name: Strip binaries
+  #       if: ${{ matrix.strip }}
+  #       run: |
+  #         strip bin/godot.*
 
-      # - name: Shrink debug symbols
-      #   if: ${{ !matrix.strip }}
-      #   run: |
-      #     # remove duplicate symbols from binary
-      #     dwz ${{ matrix.bin }} -L none -o Middleman.debug
-      #     # make the debug symbols compressed
-      #     objcopy --compress-debug-sections Middleman.debug FinalMan.debug
-      #     # overwrite the original file
-      #     mv FinalMan.debug ${{ matrix.bin }}
+  #     # - name: Shrink debug symbols
+  #     #   if: ${{ !matrix.strip }}
+  #     #   run: |
+  #     #     # remove duplicate symbols from binary
+  #     #     dwz ${{ matrix.bin }} -L none -o Middleman.debug
+  #     #     # make the debug symbols compressed
+  #     #     objcopy --compress-debug-sections Middleman.debug FinalMan.debug
+  #     #     # overwrite the original file
+  #     #     mv FinalMan.debug ${{ matrix.bin }}
 
-      - name: Prepare artifact
-        if: ${{ matrix.artifact }}
-        run: |
-          chmod +x bin/godot.*
-          mv ${{ matrix.bin }} bin/${{ matrix.artifact-name }}
+  #     - name: Prepare artifact
+  #       if: ${{ matrix.artifact }}
+  #       run: |
+  #         chmod +x bin/godot.*
+  #         mv ${{ matrix.bin }} bin/${{ matrix.artifact-name }}
 
-      - name: Upload artifact
-        uses: ./.github/actions/upload-artifact
-        if: ${{ matrix.artifact }}
-        with:
-          path: ./godot-engine/bin/${{ matrix.artifact-name }}
-          name: ${{ matrix.artifact-name }}
+  #     - name: Upload artifact
+  #       uses: ./.github/actions/upload-artifact
+  #       if: ${{ matrix.artifact }}
+  #       with:
+  #         path: ./godot-engine/bin/${{ matrix.artifact-name }}
+  #         name: ${{ matrix.artifact-name }}

--- a/.github/workflows/engine.yml
+++ b/.github/workflows/engine.yml
@@ -136,6 +136,7 @@ jobs:
   build-macos:
     runs-on: "macos-latest"
     name: ${{ matrix.name }}
+    environment: ${{ inputs.environment }}
     strategy:
       fail-fast: false
       matrix:
@@ -276,6 +277,7 @@ jobs:
   build-linux:
     runs-on: "ubuntu-20.04" # MUST run on the old version for GLIBC compatibility
     name: ${{ matrix.name }}
+    environment: ${{ inputs.environment }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/engine.yml
+++ b/.github/workflows/engine.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Upload binary
         uses: 'google-github-actions/upload-cloud-storage@v2'
         with:
-          path: bin/${{ matrix.artifact-name }}
+          path: ./godot-engine/bin/${{ matrix.artifact-name }}
           destination: ${{ matrix.bucket-name }}/${{steps.vars.outputs.sha_short}}/
   build-macos:
     runs-on: "macos-latest"

--- a/.github/workflows/engine.yml
+++ b/.github/workflows/engine.yml
@@ -1,12 +1,16 @@
 name: Engine
 on:
-    workflow_call:
-      secrets:
-        GCP_BUCKET_UPLOAD:
-          required: true
-      outputs:
-        commit_hash:
-          value: ${{ jobs.build-windows.outputs.commit_hash }}
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
+    secrets:
+      GCP_BUCKET_UPLOAD:
+        required: true
+    outputs:
+      commit_hash:
+        value: ${{ jobs.build-windows.outputs.commit_hash }}
 
 defaults:
   run:
@@ -31,6 +35,7 @@ jobs:
   build-windows:
     runs-on: "windows-latest"
     name: ${{ matrix.name }}
+    environment: ${{ inputs.environment }}
     strategy:
       fail-fast: false
       matrix:
@@ -113,8 +118,7 @@ jobs:
           path: ./godot-engine/bin/${{ matrix.artifact-name }}.exe
           name: ${{ matrix.artifact-name }}.exe
 
-      - name: Google Cloud Platform authentication
-        uses: 'google-github-actions/auth@v2'
+      - uses: 'google-github-actions/auth@v2'
         with:
           credentials_json: '${{ secrets.GCP_BUCKET_UPLOAD }}'
 

--- a/.github/workflows/engine.yml
+++ b/.github/workflows/engine.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Upload binary
         uses: 'google-github-actions/upload-cloud-storage@v2'
         with:
-          path: ./godot-engine/bin/${{ matrix.artifact-name }}
+          path: ./godot-engine/bin/${{ matrix.artifact-name }}.exe
           destination: ${{ matrix.bucket-name }}/${{steps.vars.outputs.sha_short}}/
   build-macos:
     runs-on: "macos-latest"

--- a/.github/workflows/engine.yml
+++ b/.github/workflows/engine.yml
@@ -15,6 +15,7 @@ on:
 defaults:
   run:
     working-directory: ./godot-engine
+    shell: bash
 
 # Global Settings
 env:
@@ -73,6 +74,7 @@ jobs:
         run: |
           echo "Git hash: $(git rev-parse --short=8 HEAD)"
           echo "sha_short=$(git rev-parse --short=8 HEAD)" >> $GITHUB_OUTPUT
+
 
       - name: Test Hash exists
         run: echo "Test value is ${{steps.vars.outputs.sha_short}}"

--- a/.github/workflows/engine.yml
+++ b/.github/workflows/engine.yml
@@ -74,8 +74,9 @@ jobs:
           echo "Git hash: $(git rev-parse --short=8 HEAD)"
           echo "sha_short=$(git rev-parse --short=8 HEAD)" >> $Env:GITHUB_OUTPUT
 
-      - name: Test Hash exists
-        run: echo "Test value is ${{steps.vars.outputs.sha_short}}"
+      - name: Ensuring git hash exists (or will fail job)
+        if: steps.vars.outputs.sha_short == ''
+        run: exit 1
 
       - name: Setup Godot build cache
         uses: ./godot-engine/.github/actions/godot-cache
@@ -132,202 +133,248 @@ jobs:
         with:
           path: ./godot-engine/bin/${{ matrix.artifact-name }}.exe
           destination: ${{ matrix.bucket-name }}/${{steps.vars.outputs.sha_short}}/
-  # build-macos:
-  #   runs-on: "macos-latest"
-  #   name: ${{ matrix.name }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       include:
-  #         - name: MacOS Editor
-  #           cache-name: macos-editor
-  #           target: editor
-  #           tests: false
-  #           strip: true
-  #           sconsflags: debug_symbols=no optimize=speed production=yes
-  #           dist-app: "macos_tools.app"
-  #           packaged-app: "MirrorGodotEditorMac.app"
-  #           bin-name: "godot.macos.editor.universal"
-  #           bin-name-x86_64: "godot.macos.editor.x86_64"
-  #           bin-name-arm64: "godot.macos.editor.arm64"
-  #           artifact-bin-name: "Godot"
-  #           artifact-name: "MirrorGodotEditorMac.app"
+  build-macos:
+    runs-on: "macos-latest"
+    name: ${{ matrix.name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: MacOS Editor
+            cache-name: macos-editor
+            target: editor
+            tests: false
+            strip: true
+            sconsflags: debug_symbols=no optimize=speed production=yes
+            dist-app: "macos_tools.app"
+            packaged-app: "MirrorGodotEditorMac.app"
+            bin-name: "godot.macos.editor.universal"
+            bin-name-x86_64: "godot.macos.editor.x86_64"
+            bin-name-arm64: "godot.macos.editor.arm64"
+            artifact-bin-name: "Godot"
+            artifact-name: "MirrorGodotEditorMac.app"
+            bucket-name: mirror_native_client_builds/Engine
 
-  #         - name: MacOS Template
-  #           cache-name: macos-template
-  #           target: template_debug
-  #           tests: false
-  #           strip: true
-  #           sconsflags: debug_symbols=no optimize=speed
-  #           dist-app: "macos_template.app"
-  #           packaged-app: "macos_template.app"
-  #           bin-name: "godot.macos.template_debug.universal"
-  #           bin-name-x86_64: "godot.macos.template_debug.x86_64"
-  #           bin-name-arm64: "godot.macos.template_debug.arm64"
-  #           artifact-bin-name: "godot_macos_release.universal"
-  #           artifact-name: "macos_template.app"
+          - name: MacOS Template
+            cache-name: macos-template
+            target: template_debug
+            tests: false
+            strip: true
+            sconsflags: debug_symbols=no optimize=speed
+            dist-app: "macos_template.app"
+            packaged-app: "macos_template.app"
+            bin-name: "godot.macos.template_debug.universal"
+            bin-name-x86_64: "godot.macos.template_debug.x86_64"
+            bin-name-arm64: "godot.macos.template_debug.arm64"
+            artifact-bin-name: "godot_macos_release.universal"
+            artifact-name: "macos_template.app"
+            bucket-name: mirror_native_client_builds/Engine
 
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #       with:
-  #         submodules: recursive
-  #     - name: Setup python and scons
-  #       uses: ./godot-engine/.github/actions/godot-deps
-  #     - name: Setup Vulkan SDK
-  #       run: |
-  #         # Download and install the Vulkan SDK.
-  #         curl -L "https://sdk.lunarg.com/sdk/download/latest/mac/vulkan-sdk.dmg" -o /tmp/vulkan-sdk.dmg
-  #         hdiutil attach /tmp/vulkan-sdk.dmg -mountpoint /Volumes/vulkan-sdk
-  #         /Volumes/vulkan-sdk/InstallVulkan.app/Contents/MacOS/InstallVulkan \
-  #             --accept-licenses --default-answer --confirm-command install
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
-  #     - name: Setup Godot build cache
-  #       uses: ./godot-engine/.github/actions/godot-cache
-  #       with:
-  #         cache-name: ${{ matrix.cache-name }}
-  #       continue-on-error: true
+      - name: Get short commit hash
+        id: vars
+        run: |
+          echo "Git hash: $(git rev-parse --short=8 HEAD)"
+          echo "sha_short=$(git rev-parse --short=8 HEAD)" >> $GITHUB_OUTPUT
 
-  #     - name: Setup scons (python is already installed on self-hosted runners!)
-  #       shell: bash
-  #       run: |
-  #         python3 -c "import sys; print(sys.version)"
-  #         python3 -m ensurepip --upgrade
-  #         python3 -m pip install --user scons
-  #         scons --version
+      - name: Ensuring git hash exists (or will fail job)
+        if: steps.vars.outputs.sha_short == ''
+        run: exit 1
 
-  #     - name: Setup cmake
-  #       shell: bash
-  #       run: |
-  #         brew install cmake
-  #         cmake --version
+      - name: Setup python and scons
+        uses: ./godot-engine/.github/actions/godot-deps
 
-  #     - name: Remove existing binaries
-  #       run: |
-  #         rm -Rf bin/
+      - name: Setup Vulkan SDK
+        run: |
+          # Download and install the Vulkan SDK.
+          curl -L "https://sdk.lunarg.com/sdk/download/latest/mac/vulkan-sdk.dmg" -o /tmp/vulkan-sdk.dmg
+          hdiutil attach /tmp/vulkan-sdk.dmg -mountpoint /Volumes/vulkan-sdk
+          /Volumes/vulkan-sdk/InstallVulkan.app/Contents/MacOS/InstallVulkan \
+              --accept-licenses --default-answer --confirm-command install
 
-  #     - name: Compilation (x86_64)
-  #       uses: ./.github/actions/godot-build
-  #       with:
-  #         sconsflags: ${{ env.SCONSFLAGS }} arch=x86_64
-  #         platform: macos
-  #         target: ${{ matrix.target }}
-  #         tests: ${{ matrix.tests }}
+      - name: Setup Godot build cache
+        uses: ./godot-engine/.github/actions/godot-cache
+        with:
+          cache-name: ${{ matrix.cache-name }}
+        continue-on-error: true
 
-  #     - name: Compilation (arm64)
-  #       uses: ./.github/actions/godot-build
-  #       with:
-  #         sconsflags: ${{ env.SCONSFLAGS }} arch=arm64
-  #         platform: macos
-  #         target: ${{ matrix.target }}
-  #         tests: ${{ matrix.tests }}
+      - name: Setup scons (python is already installed on self-hosted runners!)
+        shell: bash
+        run: |
+          python3 -c "import sys; print(sys.version)"
+          python3 -m ensurepip --upgrade
+          python3 -m pip install --user scons
+          scons --version
 
-  #     - name: Strip binaries
-  #       if: ${{ matrix.strip }}
-  #       run: |
-  #         echo "Stripping binaries"
-  #         strip bin/*
+      - name: Setup cmake
+        shell: bash
+        run: |
+          brew install cmake
+          cmake --version
 
-  #     - name: Prepare universal executable
-  #       run: |
-  #         lipo -create bin/${{ matrix.bin-name-x86_64 }} bin/${{ matrix.bin-name-arm64 }} -output bin/${{ matrix.bin-name }}
-  #         chmod -R +x bin/*
+      - name: Remove existing binaries
+        run: |
+          rm -Rf bin/
 
-  #     - name: Package in macOS app bundle
-  #       shell: sh
-  #       run: |
-  #         cp -R misc/dist/${{ matrix.dist-app }} bin/${{ matrix.packaged-app }}
-  #         cd bin/
-  #         mkdir -p ${{ matrix.packaged-app }}/Contents/MacOS
-  #         cp ${{ matrix.bin-name }} ${{ matrix.packaged-app }}/Contents/MacOS/${{ matrix.artifact-bin-name }}
-  #         chmod -R +x ${{ matrix.packaged-app }}
-  #         xattr -rc ${{ matrix.packaged-app }}
-  #         zip -q -9 -r ${{ matrix.artifact-name }}.zip ${{ matrix.packaged-app }}
+      - name: Compilation (x86_64)
+        uses: ./.github/actions/godot-build
+        with:
+          sconsflags: ${{ env.SCONSFLAGS }} arch=x86_64
+          platform: macos
+          target: ${{ matrix.target }}
+          tests: ${{ matrix.tests }}
 
-  #     - name: Upload artifact
-  #       uses: ./.github/actions/upload-artifact
-  #       with:
-  #         name: "${{ matrix.artifact-name }}.zip"
-  #         path: "./godot-engine/bin/${{ matrix.artifact-name }}.zip"
-  # build-linux:
-  #   runs-on: "ubuntu-20.04" # MUST run on the old version for GLIBC compatibility
-  #   name: ${{ matrix.name }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       include:
-  #         - name: Linux Editor
-  #           cache-name: linux-editor
-  #           target: editor
-  #           sconsflags: arch=x86_64 debug_symbols=no optimize=speed production=yes
-  #           strip: false
-  #           bin: "./bin/godot.linuxbsd.editor.x86_64"
-  #           artifact-name: "MirrorGodotEditorLinux.x86_64"
-  #           artifact: true
-  #           tests: no
+      - name: Compilation (arm64)
+        uses: ./.github/actions/godot-build
+        with:
+          sconsflags: ${{ env.SCONSFLAGS }} arch=arm64
+          platform: macos
+          target: ${{ matrix.target }}
+          tests: ${{ matrix.tests }}
 
-  #         - name: Linux Template
-  #           cache-name: linux-template
-  #           target: template_debug
-  #           strip: true
-  #           sconsflags: arch=x86_64 debug_symbols=no optimize=speed
-  #           bin: "./bin/godot.linuxbsd.template_debug.x86_64"
-  #           artifact-name: "linux_release.x86_64"
-  #           artifact: true
-  #           tests: no
+      - name: Strip binaries
+        if: ${{ matrix.strip }}
+        run: |
+          echo "Stripping binaries"
+          strip bin/*
 
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #       with:
-  #         submodules: recursive
+      - name: Prepare universal executable
+        run: |
+          lipo -create bin/${{ matrix.bin-name-x86_64 }} bin/${{ matrix.bin-name-arm64 }} -output bin/${{ matrix.bin-name }}
+          chmod -R +x bin/*
 
-  #     - name: Setup Godot build cache
-  #       uses: ./godot-engine/.github/actions/godot-cache
-  #       with:
-  #         cache-name: ${{ matrix.cache-name }}
-  #       continue-on-error: true
+      - name: Package in macOS app bundle
+        shell: sh
+        run: |
+          cp -R misc/dist/${{ matrix.dist-app }} bin/${{ matrix.packaged-app }}
+          cd bin/
+          mkdir -p ${{ matrix.packaged-app }}/Contents/MacOS
+          cp ${{ matrix.bin-name }} ${{ matrix.packaged-app }}/Contents/MacOS/${{ matrix.artifact-bin-name }}
+          chmod -R +x ${{ matrix.packaged-app }}
+          xattr -rc ${{ matrix.packaged-app }}
+          zip -q -9 -r ${{ matrix.artifact-name }}.zip ${{ matrix.packaged-app }}
 
-  #     - name: Setup scons
-  #       shell: bash
-  #       run: |
-  #         python -c "import sys; print(sys.version)"
-  #         python -m pip install scons==4.4.0
-  #         scons --version
+      - name: Upload artifact
+        uses: ./.github/actions/upload-artifact
+        with:
+          name: "${{ matrix.artifact-name }}.zip"
+          path: "./godot-engine/bin/${{ matrix.artifact-name }}.zip"
 
-  #     - name: Setup GCC problem matcher
-  #       uses: ammaraskar/gcc-problem-matcher@master
+      - uses: 'google-github-actions/auth@v2'
+        with:
+          credentials_json: '${{ secrets.GCP_BUCKET_UPLOAD }}'
 
-  #     - name: Compilation
-  #       uses: ./.github/actions/godot-build
-  #       with:
-  #         sconsflags: ${{ env.SCONSFLAGS }} ${{ matrix.sconsflags }}
-  #         platform: linuxbsd
-  #         target: ${{ matrix.target }}
-  #         tests: ${{ matrix.tests }}
+      - name: Upload binary
+        uses: 'google-github-actions/upload-cloud-storage@v2'
+        with:
+          path: ./godot-engine/bin/${{ matrix.artifact-name }}.zip
+          destination: ${{ matrix.bucket-name }}/${{steps.vars.outputs.sha_short}}/
+  build-linux:
+    runs-on: "ubuntu-20.04" # MUST run on the old version for GLIBC compatibility
+    name: ${{ matrix.name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux Editor
+            cache-name: linux-editor
+            target: editor
+            sconsflags: arch=x86_64 debug_symbols=no optimize=speed production=yes
+            strip: false
+            bin: "./bin/godot.linuxbsd.editor.x86_64"
+            artifact-name: "MirrorGodotEditorLinux.x86_64"
+            artifact: true
+            tests: no
+            bucket-name: mirror_native_client_builds/Engine
 
-  #     - name: Strip binaries
-  #       if: ${{ matrix.strip }}
-  #       run: |
-  #         strip bin/godot.*
+          - name: Linux Template
+            cache-name: linux-template
+            target: template_debug
+            strip: true
+            sconsflags: arch=x86_64 debug_symbols=no optimize=speed
+            bin: "./bin/godot.linuxbsd.template_debug.x86_64"
+            artifact-name: "linux_release.x86_64"
+            artifact: true
+            tests: no
+            bucket-name: mirror_native_client_builds/Engine
 
-  #     # - name: Shrink debug symbols
-  #     #   if: ${{ !matrix.strip }}
-  #     #   run: |
-  #     #     # remove duplicate symbols from binary
-  #     #     dwz ${{ matrix.bin }} -L none -o Middleman.debug
-  #     #     # make the debug symbols compressed
-  #     #     objcopy --compress-debug-sections Middleman.debug FinalMan.debug
-  #     #     # overwrite the original file
-  #     #     mv FinalMan.debug ${{ matrix.bin }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
-  #     - name: Prepare artifact
-  #       if: ${{ matrix.artifact }}
-  #       run: |
-  #         chmod +x bin/godot.*
-  #         mv ${{ matrix.bin }} bin/${{ matrix.artifact-name }}
+      - name: Get short commit hash
+        id: vars
+        run: |
+          echo "Git hash: $(git rev-parse --short=8 HEAD)"
+          echo "sha_short=$(git rev-parse --short=8 HEAD)" >> $GITHUB_OUTPUT
 
-  #     - name: Upload artifact
-  #       uses: ./.github/actions/upload-artifact
-  #       if: ${{ matrix.artifact }}
-  #       with:
-  #         path: ./godot-engine/bin/${{ matrix.artifact-name }}
-  #         name: ${{ matrix.artifact-name }}
+      - name: Ensuring git hash exists (or will fail job)
+        if: steps.vars.outputs.sha_short == ''
+        run: exit 1
+
+      - name: Setup Godot build cache
+        uses: ./godot-engine/.github/actions/godot-cache
+        with:
+          cache-name: ${{ matrix.cache-name }}
+        continue-on-error: true
+
+      - name: Setup scons
+        shell: bash
+        run: |
+          python -c "import sys; print(sys.version)"
+          python -m pip install scons==4.4.0
+          scons --version
+
+      - name: Setup GCC problem matcher
+        uses: ammaraskar/gcc-problem-matcher@master
+
+      - name: Compilation
+        uses: ./.github/actions/godot-build
+        with:
+          sconsflags: ${{ env.SCONSFLAGS }} ${{ matrix.sconsflags }}
+          platform: linuxbsd
+          target: ${{ matrix.target }}
+          tests: ${{ matrix.tests }}
+
+      - name: Strip binaries
+        if: ${{ matrix.strip }}
+        run: |
+          strip bin/godot.*
+
+      # - name: Shrink debug symbols
+      #   if: ${{ !matrix.strip }}
+      #   run: |
+      #     # remove duplicate symbols from binary
+      #     dwz ${{ matrix.bin }} -L none -o Middleman.debug
+      #     # make the debug symbols compressed
+      #     objcopy --compress-debug-sections Middleman.debug FinalMan.debug
+      #     # overwrite the original file
+      #     mv FinalMan.debug ${{ matrix.bin }}
+
+      - name: Prepare artifact
+        if: ${{ matrix.artifact }}
+        run: |
+          chmod +x bin/godot.*
+          mv ${{ matrix.bin }} bin/${{ matrix.artifact-name }}
+
+      - name: Upload artifact
+        uses: ./.github/actions/upload-artifact
+        if: ${{ matrix.artifact }}
+        with:
+          path: ./godot-engine/bin/${{ matrix.artifact-name }}
+          name: ${{ matrix.artifact-name }}
+
+      - uses: 'google-github-actions/auth@v2'
+        with:
+          credentials_json: '${{ secrets.GCP_BUCKET_UPLOAD }}'
+
+      - name: Upload binary
+        uses: 'google-github-actions/upload-cloud-storage@v2'
+        with:
+          path: ./godot-engine/bin/${{ matrix.artifact-name }}.zip
+          destination: ${{ matrix.bucket-name }}/${{steps.vars.outputs.sha_short}}/


### PR DESCRIPTION
Why?
- We kept having bugs when ingesting the binaries into github steps, 50 percent of the time it would fail and keep failing or the artefacts were deleted by GitHub.
- I just implemented a bucket to upload these binaries in GCP as it is 3 times faster, and also always is guaranteed to actually function for our development branch.
- We're working towards getting a full release out soon.

Changes:
- Split the engine and the app build into separate files
- Used composite job for the engine build so we can easily invoke it at the correct phase
- Upload the binaries to GCP and GitHub artefacts, so that the GCP bucket contains a binary for each engine hash.
- Add hash checker to ensure builds fail as early as possible if this is missing.
- Ensure we build the engine before building the app.
- Format fixes.

Important (ONLY FOR Pull Requests. on the dev branch **on the dev branch this is totally automatic**):
- **Engine builds must update the Engine / Template hash manually until we make some additional changes to this code**

Future:
- We can re-merge the deployment-pr.yml once we have some simple code to grab the correct engine hash without running the engine.yml file. (right now the editor and template are just static links but only in the PR context)
- In the engine build context (on the dev branch we can safely upload engine binaries as they have been vetted)