### PR TITLE
Fix race condition, cache was never loaded on certain machines causing insane load times

### DIFF
--- a/mirror-godot-app/scripts/net/file_cache.gd
+++ b/mirror-godot-app/scripts/net/file_cache.gd
@@ -17,8 +17,10 @@ class KeyPromisePair:
 ## Initializes and loads the file cache library json into memory on startup.
 func _init() -> void:
 	# wait a bit to ensure is status of this aplication is determined (server or client)
-	_load_stored_files_cache.call_deferred()
-	_setup_storage_directory.call_deferred()
+	await Zone.wait_till_booted()
+	_load_stored_files_cache()
+	_setup_storage_directory()
+
 
 
 func _process(_delta: float) -> void:

--- a/mirror-godot-app/scripts/net/file_client.gd
+++ b/mirror-godot-app/scripts/net/file_client.gd
@@ -11,7 +11,7 @@ const _AVATARS_CFG_PATH: String = "res://avatars.cfg"
 var files: Dictionary = Dictionary()
 var resource_avatars: Dictionary = Dictionary()
 
-var _file_cache: FileCache = FileCache.new()
+var _file_cache: FileCache = await FileCache.new()
 var _file_requests_queued: Dictionary = {}
 
 


### PR DESCRIPTION
Why?
- Call_deferred never happened after init() until much later, literally minutes.
- All downloads would fail unless this cache was loaded at the correct moment.
- Waiting for server to start, then opening cache is the best answer.
- Fixes Liza's pc being unable to join.

Errors fixed:
```
Error loading file for asset: 6585cb3dd84186f81f2485d4 Err: Unable to load a file: https://storage.googleapis.com/the-mirror-backend-prod-asset-uploads-public/635946cb2410dba56898b0d9/assets/6585cb3dd84186f81f2485d4/files/6585cb3ed84186f81f248630.glb
```