### PR TITLE
Increase flexibility of allowed avatar node structures

### DIFF
--- a/mirror-godot-app/project.godot
+++ b/mirror-godot-app/project.godot
@@ -80,7 +80,6 @@ global_script_class_icons={
 [application]
 
 config/name="The Mirror"
-config/version=""
 run/main_scene="res://scenes/boot_scene.tscn"
 config/features=PackedStringArray("4.3", "4309e8e8", "mirror")
 boot_splash/bg_color=Color(0.0745098, 0.0862745, 0.184314, 1)


### PR DESCRIPTION
Previously, we only supported node structures that matched RPM exactly, so like this:

```
<root>
    Armature
        Skeleton3D
```

This PR makes our detection more flexible, so now it can handle this case:

```
<root>
    <any name>
        Skeleton3D
```

And handle this case:

```
<root>
    Skeleton3D
```

As a bonus, this PR adds code to handle the case of when the eye bones are missing (look for the Head instead).

Tested and working with an RPM avatar, my Rosavali, and a carefully-crafted VRM renamed to .glb (note that The Mirror does not yet support arbitrary VRM files).