### PR TITLE
CI/CD - Add self hosted support, and add some basic vscode suggestions and fixes

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: dev
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_SECRET_WRITE_TOKEN }}
 

--- a/.github/workflows/client-build-tool.yml
+++ b/.github/workflows/client-build-tool.yml
@@ -111,7 +111,7 @@ on:
         value: ${{ jobs.client-build-tool.outputs.version }}
     secrets:
       gcp-secret:
-        required: false
+        required: true
       cicd-token-github:
         required: true
       ITCH_IO_CICD:

--- a/.github/workflows/deployment-pr.yml
+++ b/.github/workflows/deployment-pr.yml
@@ -36,7 +36,7 @@ jobs:
       game-export-preset: Windows
       game-binary-name: The Mirror Dev.exe
       bucket-name: no-bucket
-      os: "windows-latest"
+      os: ${{ github.event.repository.name != 'the-mirror' && fromJSON('[ "self-hosted", "Windows"]') || 'windows-latest' }}
       # TODO: This will be dynamic in future and we can't do that immediately as we have to focus on the deployment side.
       editor-download-url: https://storage.googleapis.com/mirror_native_client_builds/Engine/4309e8e8/MirrorGodotEditorWindows.exe
       template-download-url: https://storage.googleapis.com/mirror_native_client_builds/Engine/4309e8e8/windows_release_x86_64.exe
@@ -65,7 +65,7 @@ jobs:
       game-export-preset: MacOS-themirror-dev
       game-binary-name: The Mirror Dev.app
       bucket-name: no-bucket
-      os: "macos-latest"
+      os: ${{ github.event.repository.name != 'the-mirror' && fromJSON('[ "self-hosted", "MacOS"]') || 'macos-latest' }}
       # TODO: This will be dynamic in future and we can't do that immediately as we have to focus on the deployment side.
       editor-download-url: https://storage.googleapis.com/mirror_native_client_builds/Engine/4309e8e8/MirrorGodotEditorMac.app.zip
       template-download-url: https://storage.googleapis.com/mirror_native_client_builds/Engine/4309e8e8/macos_template.app.zip
@@ -92,7 +92,7 @@ jobs:
       game-export-preset: Linux
       game-binary-name: The Mirror Dev.x86_64
       bucket-name: no-bucket
-      os: "ubuntu-20.04"
+      os: ${{ github.event.repository.name != 'the-mirror' && fromJSON('[ "self-hosted", "Linux"]') || 'ubuntu-20.04' }}
       # TODO: This will be dynamic in future and we can't do that immediately as we have to focus on the deployment side.
       editor-download-url: https://storage.googleapis.com/mirror_native_client_builds/Engine/4309e8e8/MirrorGodotEditorLinux.x86_64
       template-download-url: https://storage.googleapis.com/mirror_native_client_builds/Engine/4309e8e8/linux_release.x86_64

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -18,6 +18,7 @@ jobs:
       GCP_BUCKET_UPLOAD: ${{ secrets.GCP_BUCKET_UPLOAD }}
     with:
       environment: "dev"
+      self-hosted-runner: ${{ github.event.repository.name != 'the-mirror' }}
 
   build-windows-client:
     name: 🏁 Build Windows Dev PR
@@ -43,7 +44,7 @@ jobs:
       game-export-preset: Windows
       game-binary-name: The Mirror Dev.exe
       bucket-name: no-bucket
-      os: "windows-latest"
+      os: ${{ github.event.repository.name != 'the-mirror' && fromJSON('[ "self-hosted", "Windows"]') || 'windows-latest' }}
       editor-download-url: https://storage.googleapis.com/mirror_native_client_builds/Engine/${{needs.get-or-build-engine.outputs.commit_hash}}/MirrorGodotEditorWindows.exe
       template-download-url: https://storage.googleapis.com/mirror_native_client_builds/Engine/${{needs.get-or-build-engine.outputs.commit_hash}}/windows_release_x86_64.exe
   build-macos-client:
@@ -72,7 +73,7 @@ jobs:
       game-export-preset: MacOS-themirror-dev
       game-binary-name: The Mirror Dev.app
       bucket-name: no-bucket
-      os: "macos-latest"
+      os: ${{ github.event.repository.name != 'the-mirror' && fromJSON('[ "self-hosted", "MacOS"]') || 'macos-latest' }}
       editor-download-url: https://storage.googleapis.com/mirror_native_client_builds/Engine/${{needs.get-or-build-engine.outputs.commit_hash}}/MirrorGodotEditorMac.app.zip
       template-download-url: https://storage.googleapis.com/mirror_native_client_builds/Engine/${{needs.get-or-build-engine.outputs.commit_hash}}/macos_template.app.zip
   build-linux-client:
@@ -99,6 +100,6 @@ jobs:
       game-export-preset: Linux
       game-binary-name: The Mirror Dev.x86_64
       bucket-name: no-bucket
-      os: "ubuntu-20.04"
+      os: ${{ github.event.repository.name != 'the-mirror' && fromJSON('[ "self-hosted", "Linux"]') || 'ubuntu-20.04' }}
       editor-download-url: https://storage.googleapis.com/mirror_native_client_builds/Engine/${{needs.get-or-build-engine.outputs.commit_hash}}/MirrorGodotEditorLinux.x86_64
       template-download-url: https://storage.googleapis.com/mirror_native_client_builds/Engine/${{needs.get-or-build-engine.outputs.commit_hash}}/linux_release.x86_64

--- a/.github/workflows/engine.yml
+++ b/.github/workflows/engine.yml
@@ -5,6 +5,9 @@ on:
       environment:
         required: true
         type: string
+      self-hosted-runner:
+        required: true
+        type: boolean
     secrets:
       GCP_BUCKET_UPLOAD:
         required: true
@@ -33,7 +36,7 @@ concurrency:
 
 jobs:
   build-windows:
-    runs-on: "windows-latest"
+    runs-on: ${{ inputs.self-hosted-runner && fromJSON('[ "self-hosted", "Windows"]') || 'windows-latest' }}
     name: ${{ matrix.name }}
     environment: ${{ inputs.environment }}
     strategy:
@@ -134,7 +137,7 @@ jobs:
           path: ./godot-engine/bin/${{ matrix.artifact-name }}.exe
           destination: ${{ matrix.bucket-name }}/${{steps.vars.outputs.sha_short}}/
   build-macos:
-    runs-on: "macos-latest"
+    runs-on: ${{ inputs.self-hosted-runner && fromJSON('[ "self-hosted", "MacOS"]') || 'macos-latest' }}
     name: ${{ matrix.name }}
     environment: ${{ inputs.environment }}
     strategy:
@@ -275,7 +278,7 @@ jobs:
           path: ./godot-engine/bin/${{ matrix.artifact-name }}.zip
           destination: ${{ matrix.bucket-name }}/${{steps.vars.outputs.sha_short}}/
   build-linux:
-    runs-on: "ubuntu-20.04" # MUST run on the old version for GLIBC compatibility
+    runs-on: ${{ inputs.self-hosted-runner && fromJSON('[ "self-hosted", "Linux"]') || 'ubuntu-20.04' }}
     name: ${{ matrix.name }}
     environment: ${{ inputs.environment }}
     strategy:

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,13 @@
+{
+    "recommendations": [
+        "streetsidesoftware.code-spell-checker",
+        "ms-vscode.cpptools",
+        "ms-vscode.cpptools-themes",
+        "ms-vscode.cpptools-extension-pack",
+        "geequlim.godot-tools",
+        "esbenp.prettier-vscode",
+        "ms-python.python",
+        "ms-python.debugpy",
+        "ms-python.vscode-pylance"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,19 @@
+{
+    // Ensure that copy pasting in .vscode always works with YML files
+    // This means you can copy paste properly in VSCode with YML files. Like GitHub actions.
+    // It improves the situation with whitespace centric tooling.
+    "editor.autoIndent": "keep",
+    // Use the US English standard dictionary for the project.
+    // For cSpell
+    "cSpell.language": "en,en-US",
+    "cSpell.enableFiletypes": [
+        "bat",
+        "dockercompose",
+        "dockerfile",
+        "gdscript",
+        "gdshader",
+        "github-actions-workflow",
+        "makefile",
+        "shellscript"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,5 @@
 {
-    // Ensure that copy pasting in .vscode always works with YML files
-    // This means you can copy paste properly in VSCode with YML files. Like GitHub actions.
-    // It improves the situation with whitespace centric tooling.
     "editor.autoIndent": "keep",
-    // Use the US English standard dictionary for the project.
-    // For cSpell
     "cSpell.language": "en,en-US",
     "cSpell.enableFiletypes": [
         "bat",
@@ -14,6 +9,9 @@
         "gdshader",
         "github-actions-workflow",
         "makefile",
+        "markdown",
+        "typescript",
+        "typescriptreact",
         "shellscript"
     ]
 }


### PR DESCRIPTION
### Added:
- vscode files so we can work on any machine with ease.
- add self hosted optional runners

### Notes:
VSCode recommends all the plugins we use internally for Godot development, feel free to add any NEST/Node ID's to the same file. I.e formatters etc.

It will still ask the user if they should install them.

I kept copy pasting in our repo and it kept breaking so from now on the indentation when you copy paste things is maintained at the same level, before it would reformat and nuke the indenting and break github actions

I added spell checking tool called cspell. This is using the US english dictionary.

Self hosted runners can be used when from the deployment repository.