### PR TITLE
Handle integers as integers in inspector and script editor number fields

### DIFF
--- a/mirror-godot-app/creator/selection/inspector/primitive/inspector_integer_field.tscn
+++ b/mirror-godot-app/creator/selection/inspector/primitive/inspector_integer_field.tscn
@@ -1,0 +1,9 @@
+[gd_scene load_steps=2 format=3 uid="uid://dbuxetec5qt2f"]
+
+[ext_resource type="PackedScene" uid="uid://yl2tfblvbyak" path="res://creator/selection/inspector/primitive/inspector_number_field.tscn" id="1_38owa"]
+
+[node name="InspectorLabeledIntegerField" instance=ExtResource("1_38owa")]
+step = 1.0
+
+[node name="SpinBox" parent="SpinBoxHolder" index="0"]
+step = 1.0

--- a/mirror-godot-app/script/editor/variable/variable_creation_menu.gd
+++ b/mirror-godot-app/script/editor/variable/variable_creation_menu.gd
@@ -7,7 +7,7 @@ signal request_variable_creation()
 const INSPECTOR_PRIMITIVE_SCENES: Dictionary = {
 	ScriptBlock.PortType.ANY_DATA: preload("res://creator/selection/inspector/primitive/inspector_line_edit_field.tscn"),
 	ScriptBlock.PortType.BOOL: preload("res://creator/selection/inspector/primitive/inspector_bool.tscn"),
-	ScriptBlock.PortType.INT: preload("res://creator/selection/inspector/primitive/inspector_number_field.tscn"),
+	ScriptBlock.PortType.INT: preload("res://creator/selection/inspector/primitive/inspector_integer_field.tscn"),
 	ScriptBlock.PortType.FLOAT: preload("res://creator/selection/inspector/primitive/inspector_number_field.tscn"),
 	ScriptBlock.PortType.STRING: preload("res://creator/selection/inspector/primitive/inspector_line_edit_field.tscn"),
 	ScriptBlock.PortType.VECTOR2: preload("res://creator/selection/inspector/primitive/inspector_vector2.tscn"),


### PR DESCRIPTION
Before, integer input fields were just number fields. This means that The Mirror did not stop the user from inputting `1.2` into an integer, although it would later be truncated back to an integer when deserializing.

Now, there is an `inspector_integer_field.tscn` file that has a step size of 1 that is used for integers. This is a minimal derived scene that uses the same code and nodes as `inspector_number_field.tscn`. This is used in both the inspector, and in the visual script editor which uses the inspector's primitive editors.

This change was driven by a desire to have forwards compatibility with https://github.com/godotengine/godot/pull/47502

As a bonus, SpinBox will now show us arrows for integer input, which can be clicked to increment or decrement:
<img width="266" alt="Screenshot 2024-04-19 at 4 08 11 PM" src="https://github.com/the-mirror-gdp/the-mirror/assets/1646875/2717329a-ea18-478b-9ba9-dd5e1edf54af">
