### PR TITLE
Add open_source tag to repo

### DIFF
--- a/mirror-godot-app/project.godot
+++ b/mirror-godot-app/project.godot
@@ -80,6 +80,7 @@ global_script_class_icons={
 [application]
 
 config/name="The Mirror"
+config/tags=PackedStringArray("open_source")
 run/main_scene="res://scenes/boot_scene.tscn"
 config/features=PackedStringArray("4.3", "4309e8e8", "mirror")
 boot_splash/bg_color=Color(0.0745098, 0.0862745, 0.184314, 1)


### PR DESCRIPTION
Helper so you can know when you're selecting the open-source repo from the project selector:

![image](https://github.com/the-mirror-gdp/the-mirror/assets/11920077/b8229218-82e6-4ed4-947d-bcafe9fc9d52)
