### PR TITLE
Fix bumping version

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -11,6 +11,9 @@ on:
     - mirror-web-server/**
     - .github/**
 
+permissions:
+  contents: write
+
 jobs:
   bump-version:
     name: 'Bump version on dev merge'
@@ -18,8 +21,6 @@ jobs:
     environment: dev
     steps:
       - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GH_SECRET_WRITE_TOKEN }}
 
       - uses: dorny/paths-filter@v3
         id: changes
@@ -66,7 +67,7 @@ jobs:
           skip-tag: 'true'
           skip-push: 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_SECRET_WRITE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PACKAGEJSON_DIR: ./mirror-web-server
 
       - name: git status check


### PR DESCRIPTION
Problem:
- GH token doesn't have write access

Solution:
- Use the write flag for the workflow instead.