### PR TITLE
Add threading to gltf loading

### DIFF
--- a/mirror-godot-app/creator/asset_inventory/browser/recent/recents_browser_section.gd
+++ b/mirror-godot-app/creator/asset_inventory/browser/recent/recents_browser_section.gd
@@ -152,7 +152,8 @@ func _generate_new_slot(recent_asset: Dictionary) -> BaseAssetSlot:
 	slot.slot_activated.connect(_asset_browser.asset_slot_activated)
 	slot.slot_special_action.connect(_asset_browser.use_slot_asset)
 	_id_to_slot_map[recent_asset["id"]] = slot
-	_slots_flow_container.add_child(slot)
+	if slot.get_parent() == null:
+		_slots_flow_container.add_child(slot)
 	return slot
 
 

--- a/mirror-godot-app/player/cameras/camera_manager.tscn
+++ b/mirror-godot-app/player/cameras/camera_manager.tscn
@@ -1,10 +1,9 @@
-[gd_scene load_steps=6 format=3 uid="uid://brbtsnjio4p2m"]
+[gd_scene load_steps=5 format=3 uid="uid://brbtsnjio4p2m"]
 
 [ext_resource type="Script" path="res://player/cameras/camera_manager.gd" id="1_sgi5b"]
 [ext_resource type="PackedScene" uid="uid://g08bytt518wj" path="res://player/cameras/head/player_head_camera.tscn" id="2_h612i"]
 [ext_resource type="PackedScene" uid="uid://h5gnmb66fkgi" path="res://player/cameras/free/free_camera.tscn" id="4_35k1r"]
 [ext_resource type="Script" path="res://player/cameras/placement_preview.gd" id="5_h3wxg"]
-[ext_resource type="PackedScene" uid="uid://clraq8sj7pby6" path="res://player/cameras/voxel_viewer/camera_voxel_viewer.tscn" id="6_n4xo0"]
 
 [node name="CameraManager" type="Node"]
 script = ExtResource("1_sgi5b")
@@ -23,14 +22,13 @@ audio_listener_enable_3d = true
 size = Vector2i(2560, 1440)
 render_target_update_mode = 4
 
-[node name="PlayerHeadCamera" parent="SubViewportContainer/SubViewport" instance=ExtResource("2_h612i")]
+[node name="PlayerHeadCamera" parent="SubViewportContainer/SubViewport" node_paths=PackedStringArray("_camera") instance=ExtResource("2_h612i")]
+_camera = NodePath("CameraRecoilOffset/ThirdPersonCameraArm/ThirdPersonCamera")
 
-[node name="FreeCamera" parent="SubViewportContainer/SubViewport" instance=ExtResource("4_35k1r")]
+[node name="FreeCamera" parent="SubViewportContainer/SubViewport" node_paths=PackedStringArray("_camera") instance=ExtResource("4_35k1r")]
+_camera = NodePath("Camera")
 
 [node name="PlacementPreview" type="Node3D" parent="SubViewportContainer/SubViewport"]
 script = ExtResource("5_h3wxg")
 
 [node name="JoltDebugGeometry3D" type="JoltDebugGeometry3D" parent="SubViewportContainer/SubViewport"]
-
-[node name="CameraVoxelViewer" parent="." node_paths=PackedStringArray("camera_manager") instance=ExtResource("6_n4xo0")]
-camera_manager = NodePath("..")

--- a/mirror-godot-app/player/equipable/equipable_controller.gd
+++ b/mirror-godot-app/player/equipable/equipable_controller.gd
@@ -154,6 +154,9 @@ func _load_equipable_by_asset_id(asset_id: String) -> void:
 	if asset_id != _current_asset_id:
 		# It is possible that another call to this method changed the current equipable.
 		return
+	if file_promise.is_error():
+		push_error("Failed to download asset: ", file_promise.get_error_message())
+		equipable_changed.emit(null)
 	var file_result = file_promise.get_result()
 	if file_result is Node3D and file_result.has_meta(&"MIRROR_equipable"):
 		_setup_equipped_item(file_result)

--- a/mirror-godot-app/prefabs/autoload/zone/collision_shape_generator/collision_shape_generator.gd
+++ b/mirror-godot-app/prefabs/autoload/zone/collision_shape_generator/collision_shape_generator.gd
@@ -75,6 +75,9 @@ func generate_shape_for_meshes(body: JBody3D, in_meshes: Array[MeshInstance3D], 
 			if is_concave:
 				var tms: ConcavePolygonShape3D = mesh.mesh.create_trimesh_shape()
 				shape = JMeshShape3D.new()
+				if tms == null:
+					push_error("invalid physics shape")
+					continue
 				shape.faces = tms.get_faces()
 			else:
 				var cps: ConvexPolygonShape3D = mesh.mesh.create_convex_shape(false, false)

--- a/mirror-godot-app/scripts/autoload/util_funcs.gd
+++ b/mirror-godot-app/scripts/autoload/util_funcs.gd
@@ -248,27 +248,6 @@ static func looks_like_json(value) -> bool:
 	return has_braces or has_brackets
 
 
-## Loads a GLTF file from the disk as a node object.
-static func load_gltf_file_as_node(path: String) -> Variant:
-	var state: GLTFState = GLTFState.new()
-	if Zone.is_host():
-		# Discard the textures when on the server
-		state.set_handle_binary_image(GLTFState.HANDLE_BINARY_DISCARD_TEXTURES)
-	var doc: GLTFDocument = GLTFDocument.new()
-	var err = doc.append_from_file(path, state, 8)
-	if err:
-		push_error(str(err))
-		return null
-	var node: Node = doc.generate_scene(state)
-	if not is_instance_valid(node):
-		print_debug("generate_scene failed from path:", path)
-		return null
-	# Disallow importing a model with an empty root node name.
-	if node.name == &"":
-		node.name = &"Model"
-	return node
-
-
 ## Converts a GLTF document (including all its external dependencies ) to a GLB byte array.
 ## See https://github.com/the-mirror-megaverse/mirror-godot-app/pull/261 for why
 static func convert_gltf_to_glb_data(path: String) -> PackedByteArray:

--- a/mirror-godot-app/scripts/autoload/zone/client.gd
+++ b/mirror-godot-app/scripts/autoload/zone/client.gd
@@ -186,7 +186,7 @@ func _client_on_connected_to_server() -> void:
 	# note: GDScript cannot understand Zone definition unless passed via a variable in the stack.
 	var zone_autoload = Zone
 	# TODO: gordon look here this is a bit fishy. Why start syncing things before all objects exist?
-	TMSceneSync.start_sync(zone_autoload)
+	# TMSceneSync.start_sync(zone_autoload)
 
 	# wait for the space to be in a loaded enough condition to join.
 	# play servers load all objects before finishing
@@ -554,7 +554,7 @@ func _join_new_server_locally(space_id: String) -> bool:
 		var firebase_auth = str(Firebase.Auth.auth.refreshtoken)
 		# For debugging this allows you to grab breakpoints from the server "--remote-debug", "tcp://127.0.0.1:6008"]
 		# If enabled it could cause join time to be much longer when booting server
-		var arguments = ["--server", "--space", space_id, "--mode", "edit", "--uuid", "localhost", "--server_login", firebase_auth, "--headless"] # "--remote-debug", "tcp://127.0.0.1:6008"]
+		var arguments = ["--server", "--space", space_id, "--mode", "edit", "--uuid", "localhost", "--server_login", firebase_auth, "--headless", "--remote-debug", "tcp://127.0.0.1:6007"]
 		pid = OS.create_process(OS.get_executable_path(), arguments, true)
 		start_join_localhost()
 		return true

--- a/mirror-godot-app/scripts/autoload/zone/server.gd
+++ b/mirror-godot-app/scripts/autoload/zone/server.gd
@@ -534,6 +534,7 @@ func _all_files_downloaded() -> bool:
 
 
 func _init_player(peer_id, jwt, client_version) -> void:
+	print("Received client init on server at " + Time.get_datetime_string_from_system())
 	# TODO: This only decodes the JWT, but it needs to validated via Firebase SDK (probs via the NestJS server for ease)
 	# TODO: Kick the player if JWT validating fails
 	var user_id = JWT.get_user_id_from_jwt(jwt, "test123")

--- a/mirror-godot-app/scripts/net/file_client.gd
+++ b/mirror-godot-app/scripts/net/file_client.gd
@@ -83,7 +83,7 @@ func get_file(url: String, priority: Enums.DownloadPriority = Enums.DownloadPrio
 		promise.set_result(files.get(url))
 		return promise
 	if Util.path_is_model(url) and _file_cache.cached_file_exists(url):
-		var promise = _file_cache.load_model_threaded(url)
+		var promise = _file_cache.load_gltf_thread_task(url)
 		promise.connect_func_to_fulfill(_on_loaded_model_threaded.bind(url, promise))
 		return promise
 	var cached_file = _file_cache.try_load_cached_file(url)
@@ -119,7 +119,7 @@ func get_file(url: String, priority: Enums.DownloadPriority = Enums.DownloadPrio
 ## so the model gets uniquely generated from a GLTFDocument.
 ## TODO: Assess storing GLTFDocument in memory and generating node from that instead of entire file read.
 func get_model_instance_promise(url: String) -> Promise:
-	return _file_cache.load_model_threaded(url)
+	return _file_cache.load_gltf_thread_task(url)
 
 
 func _promise_fulfill_successful(request: Dictionary, promise: Promise) -> void:

--- a/mirror-godot-app/ui/game/loading_ui.gd
+++ b/mirror-godot-app/ui/game/loading_ui.gd
@@ -41,6 +41,8 @@ func _on_join_server_start() -> void:
 	show()
 
 func _on_join_server_complete() -> void:
+	GameUI.loading_ui.populate_status("")
+	print("Loading UI has been closed at: ", Time.get_datetime_string_from_system())
 	hide()
 	_progress_animation.stop()
 


### PR DESCRIPTION
Core utilization was very low on joining a space.

This copies the node from a thread to the main thread when it has been loaded.

I need to do benchmarking with a release binary to be sure there is an improvement on larger rooms.