### PR TITLE
GDScript: Fix Inspector "Add Input" button, improve tweening, add print in chat, fix entry signals, add export vars

### DIFF
--- a/mirror-godot-app/creator/selection/inspector/categories/inspector_category_toggle_button.gd
+++ b/mirror-godot-app/creator/selection/inspector/categories/inspector_category_toggle_button.gd
@@ -6,6 +6,10 @@ signal inspector_category_visibility_changed(new_visibility: bool)
 @export var expand_speed: float = 10.0
 @export var properties: Node
 
+## The text to show as a tooltip when hovering.
+## Use this instead of Godot's tooltip_text property.
+@export var hover_tooltip_text: String = ""
+
 var _is_category_visible: bool = false
 var _properties_child: Control
 var _plus_texture: TextureRect
@@ -55,3 +59,17 @@ func set_category_visible(new_is_visible):
 
 func _on_toggle_button_pressed():
 	set_category_visible(not _is_category_visible)
+
+
+func _on_hoverable_button_mouse_entered() -> void:
+	if hover_tooltip_text == "":
+		return
+	GameUI.set_hover_tooltip_text(hover_tooltip_text)
+
+
+func _on_hoverable_button_mouse_exited() -> void:
+	GameUI.hide_hover_tooltip_text()
+
+
+func _on_hoverable_button_pressed() -> void:
+	GameUI.hide_hover_tooltip_text()

--- a/mirror-godot-app/creator/selection/inspector/inspector.tscn
+++ b/mirror-godot-app/creator/selection/inspector/inspector.tscn
@@ -92,6 +92,11 @@ metadata/_edit_layout_mode = 1
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/TabContainer/Scripting/MarginContainer"]
 layout_mode = 2
 
+[node name="ScriptObjectVars" type="MarginContainer" parent="VBoxContainer/TabContainer/Scripting/MarginContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_constants/margin_top = 0
+theme_override_constants/margin_bottom = 8
+
 [node name="ScriptInstances" type="VBoxContainer" parent="VBoxContainer/TabContainer/Scripting/MarginContainer/VBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3

--- a/mirror-godot-app/creator/selection/inspector/script/inspector_script_entry_inputs.gd
+++ b/mirror-godot-app/creator/selection/inspector/script/inspector_script_entry_inputs.gd
@@ -56,11 +56,8 @@ func _setup_parameter(parameter_name: String, parameter_data: Array) -> void:
 
 
 func _on_parameter_changed(value, which: Control) -> void:
-	var parameters_for_entry: Dictionary = _target_script_instance.entry_parameters[_entry_id]
-	var param_name = which.label_text
-	var param_data = parameters_for_entry[param_name]
-	param_data[1] = value
-	_target_script_instance.apply_inspector_parameter_values()
+	var param_name: String = which.label_text
+	_target_script_instance.set_inspector_parameter_input_value(_entry_id, param_name, value)
 	_target_script_instance.script_instance_changed()
 
 
@@ -69,12 +66,7 @@ func _on_toggle_button_inspector_category_visibility_changed(new_visibility: boo
 
 
 func _on_create_parameter(parameter_port_array: Array) -> void:
-	for entry_block in _target_script_instance.script_builder.entry_blocks:
-		if entry_block.entry_id == _entry_id:
-			entry_block.parameters.create_inspector_parameter(parameter_port_array)
-			entry_block.reset_entry_output_ports()
-			break
-	_target_script_instance.sync_script_inst_params_with_script_data()
+	_target_script_instance.create_inspector_parameter_input(_entry_id, parameter_port_array)
 	_target_script_instance.script_data_contents_changed()
 	refresh_inspected_nodes.emit()
 

--- a/mirror-godot-app/creator/selection/inspector/script/inspector_script_entry_inputs.tscn
+++ b/mirror-godot-app/creator/selection/inspector/script/inspector_script_entry_inputs.tscn
@@ -7,6 +7,9 @@
 [node name="InspectorScriptEntryInputs" instance=ExtResource("1_amxtn")]
 script = ExtResource("2_adill")
 
+[node name="ToggleButton" parent="CategoryTitle" index="0" node_paths=PackedStringArray("properties")]
+properties = NodePath("../../Properties")
+
 [node name="Text" parent="CategoryTitle/ToggleButton/Name" index="3"]
 text = ""
 

--- a/mirror-godot-app/creator/selection/inspector/script/inspector_script_object_vars.gd
+++ b/mirror-godot-app/creator/selection/inspector/script/inspector_script_object_vars.gd
@@ -1,0 +1,72 @@
+extends InspectorCategoryBase
+
+
+const _TRASH_BUTTON = preload("res://creator/selection/inspector/script/entry_input_trash_button.tscn")
+
+var target_node: Node # SpaceObject or SpaceGlobalScripts
+var _is_editable: bool = false
+var _object_vars: Dictionary
+var _property_list: Control
+
+
+## Must run before _ready()
+func setup(target_object: Node, is_editable: bool) -> void:
+	target_node = target_object
+	_property_list = $Properties/MarginContainer/PropertyList
+	_is_editable = is_editable
+
+
+func setup_object_vars(object_vars: Dictionary) -> void:
+	_object_vars = object_vars
+	for obj_var_name in _object_vars:
+		_setup_object_var(obj_var_name, _object_vars[obj_var_name])
+	if _property_list.get_child_count() < 5:
+		if _property_list.get_child_count() != 0:
+			$CategoryTitle/ToggleButton.hover_tooltip_text = ""
+			set_visible_to_maximum_size()
+
+
+func _setup_object_var(obj_var_name: String, obj_var_value: Variant) -> void:
+	var obj_var_type: int = typeof(obj_var_value)
+	if obj_var_type == TYPE_NIL or not obj_var_type in ScriptParameterCreationMenu.INSPECTOR_PRIMITIVE_SCENES:
+		return
+	var obj_var_scene = ScriptParameterCreationMenu.INSPECTOR_PRIMITIVE_SCENES[obj_var_type].instantiate()
+	obj_var_scene.label_text = obj_var_name
+	obj_var_scene.reset_value = Serialization.type_convert_any(_get_default_value_of_obj_var(obj_var_name), obj_var_type)
+	# Be careful, the order matters here! Value editors with setters
+	# that use onready vars can only be used after adding as a child,
+	# and then we need to refresh if a refresh method exists.
+	_property_list.add_child(obj_var_scene)
+	obj_var_scene.current_value = obj_var_value
+	if obj_var_scene.has_method(&"refresh"):
+		obj_var_scene.refresh()
+	obj_var_scene.value_changed.connect(_on_object_var_changed.bind(obj_var_scene))
+	if _is_editable and GameplaySettings.script_show_add_inspector_input:
+		var trash_button: Node = _TRASH_BUTTON.instantiate()
+		obj_var_scene.add_child(trash_button)
+		trash_button.pressed.connect(_on_delete_object_var.bind(obj_var_name))
+
+
+func _on_object_var_changed(value, which: Control) -> void:
+	var obj_var_name: String = which.label_text
+	Zone.script_network_sync.set_variable_on_node(target_node, obj_var_name, value)
+
+
+func _on_delete_object_var(obj_var_name: String) -> void:
+	Zone.script_network_sync.set_variable_on_node(target_node, obj_var_name, null)
+	for child in _property_list.get_children():
+		child.cleanup_and_delete()
+		_property_list.remove_child(child)
+	var vars = target_node.get_meta(&"MirrorScriptObjectVariables")
+	vars.erase(obj_var_name)
+	setup_object_vars(vars)
+
+
+func _get_default_value_of_obj_var(obj_var_name: String) -> Variant:
+	var script_instances: Array[ScriptInstance] = target_node.get_script_instances()
+	for script_inst in script_instances:
+		if script_inst.has_method(&"get_default_value_of_exposed_variable"):
+			var def = script_inst.get_default_value_of_exposed_variable(obj_var_name)
+			if def != null:
+				return def
+	return null

--- a/mirror-godot-app/creator/selection/inspector/script/inspector_script_object_vars.tscn
+++ b/mirror-godot-app/creator/selection/inspector/script/inspector_script_object_vars.tscn
@@ -1,0 +1,18 @@
+[gd_scene load_steps=3 format=3 uid="uid://bhbojmr3nuwrc"]
+
+[ext_resource type="PackedScene" uid="uid://dkxqj3l0xm8uw" path="res://creator/selection/inspector/categories/inspector_category_base.tscn" id="1_ov2tq"]
+[ext_resource type="Script" path="res://creator/selection/inspector/script/inspector_script_object_vars.gd" id="2_abj1i"]
+
+[node name="InspectorScriptObjectVars" instance=ExtResource("1_ov2tq")]
+script = ExtResource("2_abj1i")
+
+[node name="ToggleButton" parent="CategoryTitle" index="0" node_paths=PackedStringArray("properties")]
+properties = NodePath("../../Properties")
+hover_tooltip_text = "Use @export in GDScript"
+
+[node name="Text" parent="CategoryTitle/ToggleButton/Name" index="3"]
+text = "OBJECT VARIABLES"
+
+[connection signal="mouse_entered" from="CategoryTitle/ToggleButton" to="CategoryTitle/ToggleButton" method="_on_hoverable_button_mouse_entered"]
+[connection signal="mouse_exited" from="CategoryTitle/ToggleButton" to="CategoryTitle/ToggleButton" method="_on_hoverable_button_mouse_exited"]
+[connection signal="pressed" from="CategoryTitle/ToggleButton" to="CategoryTitle/ToggleButton" method="_on_hoverable_button_pressed"]

--- a/mirror-godot-app/script/editor/abstract_script_editor.gd
+++ b/mirror-godot-app/script/editor/abstract_script_editor.gd
@@ -4,6 +4,7 @@ extends Control
 
 signal request_save_script_as_asset(script_instance: ScriptInstance)
 signal request_show_entry_creation_dialog(target_node: Node)
+signal request_show_custom_entry_creation_dialog(target_node: Node)
 signal request_toggle_variable_editor()
 signal request_script_editor_visibility(is_visible: bool)
 signal request_track_recently_used_space_script(script_instance: ScriptInstance)

--- a/mirror-godot-app/script/editor/entry_creation/entry_create_dialog.gd
+++ b/mirror-godot-app/script/editor/entry_creation/entry_create_dialog.gd
@@ -13,20 +13,37 @@ func _ready() -> void:
 
 func populate_and_show(target_node: Node) -> void:
 	title = "Create Script Entry"
-	_entry_creation_menu.populate_selection_tree(target_node)
+	_entry_creation_menu.populate_selection_tree(target_node, false)
 	GameUI.grab_input_lock(self)
 	popup_centered()
+	_entry_creation_menu.focus_search_bar()
+
+
+func populate_and_show_for_custom(target_node: Node) -> void:
+	_entry_creation_menu.populate_selection_tree(target_node, true)
+	_show_custom_entry_menu()
+	GameUI.grab_input_lock(self)
 	_entry_creation_menu.focus_search_bar()
 
 
 func _on_confirmed() -> void:
 	var signal_dict = _entry_creation_menu.get_desired_signal_signature()
 	if signal_dict == null:
-		title = "Create Entry With Custom Signal"
-		popup_centered()
+		_show_custom_entry_menu()
 		return
 	var block_dict: Dictionary = signal_dict.duplicate(false)
 	create_entry_block.emit(block_dict)
+
+
+func _show_custom_entry_menu() -> void:
+	title = "Create Entry With Custom Signal"
+	popup_centered()
+	_entry_creation_menu.size = Vector2.ZERO
+	size = Vector2i.ZERO
+	await get_tree().process_frame
+	popup_centered()
+	_entry_creation_menu.size = Vector2.ZERO
+	size = Vector2i.ZERO
 
 
 func _on_script_entry_creation_menu_confirmed() -> void:

--- a/mirror-godot-app/script/editor/entry_creation/entry_creation_menu.gd
+++ b/mirror-godot-app/script/editor/entry_creation/entry_creation_menu.gd
@@ -21,15 +21,18 @@ func setup(signal_tree_populator: ScriptEntrySignalTreePopulator) -> void:
 	_signal_selection.setup(signal_tree_populator)
 
 
-func populate_selection_tree(target_node: Node) -> void:
+func populate_selection_tree(target_node: Node, for_custom: bool) -> void:
 	_target_node = target_node
 	_custom_signal_parameters.clear()
 	_add_input_button.show()
 	_custom_signal_name.text = ""
 	_signal_parameters_label.text = "Signal Inputs:"
-	_signal_selection.populate_selection_tree(target_node)
-	_signal_selection.show()
-	_custom_signal.hide()
+	if for_custom:
+		_show_custom_entry_menu()
+	else:
+		_signal_selection.populate_selection_tree(target_node)
+		_signal_selection.show()
+		_custom_signal.hide()
 
 
 func focus_search_bar() -> void:
@@ -43,14 +46,17 @@ func get_desired_signal_signature():
 	return _get_custom_signal_signature()
 
 
+func _show_custom_entry_menu() -> void:
+	_signal_selection.hide()
+	_custom_signal.show()
+
+
 func _get_selected_signal_signature():
 	var signal_dict = _signal_selection.get_selected_signal()
 	if signal_dict == null:
 		return null
 	if String(signal_dict["signal"]) == "custom_signal":
-		_signal_selection.hide()
-		_custom_signal.show()
-		_add_input_button.show()
+		_show_custom_entry_menu()
 		return null
 	return signal_dict
 
@@ -68,10 +74,14 @@ func _get_custom_signal_signature():
 	if not existing_signature.is_empty():
 		existing_signature = existing_signature.duplicate()
 		existing_signature["path"] = "self"
+		existing_signature["type"] = "entry"
 		return existing_signature
 	var ret = {
+		"entry_id": "self_" + signal_name + "_" + str(randi() % 1000000),
+		"name": "On " + signal_name.capitalize(),
 		"path": "self",
 		"signal": signal_name,
+		"type": "entry",
 	}
 	if not _custom_signal_parameters.is_empty():
 		ret["signalParameters"] = _custom_signal_parameters.duplicate(true)

--- a/mirror-godot-app/script/editor/script_editor.gd
+++ b/mirror-godot-app/script/editor/script_editor.gd
@@ -227,6 +227,10 @@ func _on_request_show_entry_creation_dialog(target_node: Node) -> void:
 	_script_entry_creation_dialog.populate_and_show(target_node)
 
 
+func _on_request_show_custom_entry_creation_dialog(target_node: Node) -> void:
+	_script_entry_creation_dialog.populate_and_show_for_custom(target_node)
+
+
 func _on_script_entry_creation_dialog_create_entry_block(block_json: Dictionary) -> void:
 	if _gd_script_editor.visible:
 		if block_json["type"] == "entry":

--- a/mirror-godot-app/script/editor/script_editor.tscn
+++ b/mirror-godot-app/script/editor/script_editor.tscn
@@ -41,11 +41,13 @@ script = ExtResource("7_w8ott")
 
 [connection signal="request_save_script_as_asset" from="VisualScriptEditor" to="." method="_on_request_save_script_as_asset"]
 [connection signal="request_script_editor_visibility" from="VisualScriptEditor" to="." method="set_visual_script_editor_visibility"]
+[connection signal="request_show_custom_entry_creation_dialog" from="VisualScriptEditor" to="." method="_on_request_show_custom_entry_creation_dialog"]
 [connection signal="request_show_entry_creation_dialog" from="VisualScriptEditor" to="." method="_on_request_show_entry_creation_dialog"]
 [connection signal="request_toggle_variable_editor" from="VisualScriptEditor" to="." method="_on_request_toggle_variable_editor"]
 [connection signal="request_track_recently_used_space_script" from="VisualScriptEditor" to="." method="_on_request_track_recently_used_space_script"]
 [connection signal="request_save_script_as_asset" from="GDScriptEditor" to="." method="_on_request_save_script_as_asset"]
 [connection signal="request_script_editor_visibility" from="GDScriptEditor" to="." method="set_gd_script_editor_visibility"]
+[connection signal="request_show_custom_entry_creation_dialog" from="GDScriptEditor" to="." method="_on_request_show_custom_entry_creation_dialog"]
 [connection signal="request_show_entry_creation_dialog" from="GDScriptEditor" to="." method="_on_request_show_entry_creation_dialog"]
 [connection signal="request_toggle_variable_editor" from="GDScriptEditor" to="." method="_on_request_toggle_variable_editor"]
 [connection signal="request_track_recently_used_space_script" from="GDScriptEditor" to="." method="_on_request_track_recently_used_space_script"]

--- a/mirror-godot-app/script/gd/gdscript_entry.gd
+++ b/mirror-godot-app/script/gd/gdscript_entry.gd
@@ -174,6 +174,21 @@ func _value_to_gdscript_literal(value: Variant, type_enum: int) -> String:
 	return str(value)
 
 
+func connect_entry_signal(script_instance_object: Object, inst_entry_parameters: Dictionary) -> void:
+	# Trivial case: No inspector parameter inputs, no bindv needed.
+	if inst_entry_parameters.is_empty():
+		entry_node.connect(entry_signal, Callable(script_instance_object, function_name))
+		return
+	# If the user added inspector parameters via "Add Input", we need to bind them to the signal.
+	var insp_inputs: Array = []
+	if inst_entry_parameters.has(entry_id):
+		var params_for_entry: Dictionary = inst_entry_parameters[entry_id]
+		for insp_param_name in params_for_entry:
+			var insp_param_data: Array = params_for_entry[insp_param_name]
+			insp_inputs.append(insp_param_data[1])
+	entry_node.connect(entry_signal, Callable(script_instance_object, function_name).bindv(insp_inputs))
+
+
 static func create_node_for_entry_signal(entry_signal: String) -> Node:
 	if entry_signal == "timeout":
 		var timer: Timer = Timer.new()

--- a/mirror-godot-app/script/gd/gdscript_instance.gd
+++ b/mirror-godot-app/script/gd/gdscript_instance.gd
@@ -179,7 +179,12 @@ func set_source_code(source_code: String) -> void:
 
 
 func create_entry(entry_json: Dictionary) -> void:
-	var new_function_name: String = entry_json["name"].to_snake_case()
+	var new_function_name: String
+	if entry_json.has("name"):
+		new_function_name = entry_json["name"].to_snake_case()
+	else:
+		new_function_name = "on_" + entry_json["signal"]
+	entry_json["function"] = new_function_name
 	for entry in _entries:
 		if entry.function_name == new_function_name:
 			return # We already have an entry for this, no need to make a new entry.
@@ -278,7 +283,10 @@ func _preprocess_and_apply_code() -> void:
 	# Supplementary entry callbacks. Keep this in sync with GDScript CodeEdit load_entry_connection_decoration.
 	if target_node is SpaceObject:
 		if _source_code.contains("func _ready("):
-			target_node.setup_done.connect(Callable(script_instance_object, &"_ready"))
+			if target_node._is_setup:
+				script_instance_object.call(&"_ready")
+			else:
+				target_node.setup_done.connect(Callable(script_instance_object, &"_ready"))
 	if _source_code.contains("func _physics_process("):
 		Zone.physics_process_every_frame.connect(Callable(script_instance_object, &"_physics_process"))
 	if _source_code.contains("func _process("):

--- a/mirror-godot-app/script/gd/mirror_singleton.gd
+++ b/mirror-godot-app/script/gd/mirror_singleton.gd
@@ -3,6 +3,28 @@ class_name Mirror
 extends Object
 
 
+# Misc.
+static func get_friendly_name(value: Variant) -> String:
+	if value is SpaceObject:
+		return value.get_space_object_name()
+	elif value is Player:
+		return value.get_player_name()
+	elif value is Node:
+		return value.name
+	elif value == null:
+		return "<null>"
+	elif not is_instance_valid(value):
+		return "<invalid instance>"
+	else:
+		# For non-Node objects, str() is the best we can do.
+		return str(value)
+
+
+static func print_in_chat(attached_object: Object, message: String, range_radius: float = INF) -> void:
+	GameUI.chat_ui.send_message_from_object(attached_object, message, range_radius)
+
+
+# Global variables.
 static func get_global_variable(variable_name: String) -> Variant:
 	return Zone.script_network_sync.get_global_variable(variable_name)
 
@@ -15,10 +37,11 @@ static func set_global_variable(variable_name: String, variable_value: Variant) 
 	Zone.script_network_sync.set_global_variable(variable_name, variable_value)
 
 
-static func tween_global_variable(variable_name: String, to_value: Variant, duration: float, trans: Tween.TransitionType, easing: Tween.EaseType) -> void:
+static func tween_global_variable(variable_name: String, to_value: Variant, duration: float, trans: Tween.TransitionType = Tween.TRANS_LINEAR, easing: Tween.EaseType = Tween.EASE_IN_OUT) -> void:
 	Zone.script_network_sync.tween_global_variable(variable_name, to_value, duration, trans, easing)
 
 
+# Object variables.
 static func get_object_variable(variable_object: Object, variable_name: String) -> Variant:
 	var object_variables = variable_object.get_meta(&"MirrorScriptObjectVariables")
 	return TMDataUtil.get_variable_by_json_path_string(object_variables, variable_name)
@@ -45,8 +68,31 @@ static func set_object_variable(variable_object: Object, variable_name: String, 
 		Zone.script_network_sync.object_variable_changed.emit(variable_object, variable_name, variable_value)
 
 
-static func tween_object_variable(variable_node: Node, variable_name: String, to_value: Variant, duration: float, trans: Tween.TransitionType, easing: Tween.EaseType) -> void:
+static func tween_object_variable(variable_node: Node, variable_name: String, to_value: Variant, duration: float, trans: Tween.TransitionType = Tween.TRANS_LINEAR, easing: Tween.EaseType = Tween.EASE_IN_OUT) -> void:
 	# Note: Unlike setting a variable, this does not apply immediately.
 	# Since tweening does not have an effect on the same frame anyway,
 	# we can afford to wait for the server to only do a synced tween.
 	Zone.script_network_sync.tween_variable_on_node(variable_node, variable_name, to_value, duration, trans, easing)
+
+
+# Object properties.
+static func get_object_property(property_object: Object, property_name: StringName) -> Variant:
+	return property_object.get(property_name)
+
+
+static func has_object_property(property_object: Object, property_name: StringName) -> bool:
+	return property_name in property_object
+
+
+static func set_object_property(property_object: Object, property_name: StringName, property_value: Variant) -> void:
+	property_object.set(property_name, property_value)
+
+
+static func tween_object_property(property_object: Object, property_name: StringName, to_value: Variant, duration: float, trans: Tween.TransitionType = Tween.TRANS_LINEAR, easing: Tween.EaseType = Tween.EASE_IN_OUT) -> void:
+	if not property_object is Node:
+		Notify.error("Cannot tween object property", "The target object is not a node, but tweening properties is only supported on nodes for now.")
+		return
+	# Note: Unlike setting a property, this does not apply immediately.
+	# Since tweening does not have an effect on the same frame anyway,
+	# we can afford to wait for the server to only do a synced tween.
+	Zone.script_network_sync.tween_property_on_node(property_object, property_name, to_value, duration, trans, easing)

--- a/mirror-godot-app/script/gd/tmusergdscript_base.gd
+++ b/mirror-godot-app/script/gd/tmusergdscript_base.gd
@@ -1,0 +1,6 @@
+class_name TMUserGDScriptBase extends Object
+
+
+signal load_exposed_vars()
+signal save_exposed_vars()
+signal tmusergdscript_runtime_error(error_str: String, frame_index: int, line_num: int, func_name: String)

--- a/mirror-godot-app/script/network_sync.gd
+++ b/mirror-godot-app/script/network_sync.gd
@@ -314,7 +314,7 @@ func _set_global_variables_network(variables: Dictionary) -> void:
 	received_variable_data_change.emit()
 
 
-func tween_global_variable(variable_name: String, to_value: Variant, duration: float, trans: Tween.TransitionType, easing: Tween.EaseType) -> void:
+func tween_global_variable(variable_name: String, to_value: Variant, duration: float, trans: Tween.TransitionType = Tween.TRANS_LINEAR, easing: Tween.EaseType = Tween.EASE_IN_OUT) -> void:
 	_net_queue_tweened_global_variables[variable_name] = [to_value, duration, trans, easing]
 
 
@@ -338,7 +338,7 @@ func _tween_global_variables_network(tweened_variables: Dictionary) -> void:
 
 
 ## Tween a user variable we store inside of a Dictionary using MethodTweener.
-func _tween_variable_in_dict(variables_dict: Dictionary, variable_name: String, from_value: Variant, to_value: Variant, duration: float, trans: Tween.TransitionType, easing: Tween.EaseType) -> void:
+func _tween_variable_in_dict(variables_dict: Dictionary, variable_name: String, from_value: Variant, to_value: Variant, duration: float, trans: Tween.TransitionType = Tween.TRANS_LINEAR, easing: Tween.EaseType = Tween.EASE_IN_OUT) -> void:
 	var split_path: PackedStringArray = TMDataUtil.split_json_path_string(variable_name)
 	var method_callable: Callable = _tween_variable_callback_method.bind(variables_dict, split_path)
 	var tween: Tween = get_tree().create_tween()
@@ -412,7 +412,7 @@ func _set_property_on_node(node: Node, property: StringName, value: Variant) -> 
 	node.set(property, value)
 
 
-func tween_property_on_node(node: Node, property: StringName, to_value: Variant, duration: float, trans: Tween.TransitionType, easing: Tween.EaseType) -> void:
+func tween_property_on_node(node: Node, property: StringName, to_value: Variant, duration: float, trans: Tween.TransitionType = Tween.TRANS_LINEAR, easing: Tween.EaseType = Tween.EASE_IN_OUT) -> void:
 	if to_value is Object:
 		Notify.error("Tween Failed", "Tweening an object is not a sensible operation. Aborting.")
 		return
@@ -446,7 +446,7 @@ func _tween_properties_on_nodes_network(nodes_tweened_properties: Dictionary) ->
 			_save_tween_results_for_later(node_path, node_tweened_properties, _set_queue_properties_on_nodes)
 
 
-func _tween_property_on_node(node: Node, property: StringName, to_value: Variant, duration: float, trans: Tween.TransitionType, easing: Tween.EaseType) -> void:
+func _tween_property_on_node(node: Node, property: StringName, to_value: Variant, duration: float, trans: Tween.TransitionType = Tween.TRANS_LINEAR, easing: Tween.EaseType = Tween.EASE_IN_OUT) -> void:
 	if not ScriptPropertyRegistration.has_registered_property(property):
 		return
 	var tween: Tween = get_tree().create_tween()
@@ -514,7 +514,7 @@ func _set_variable_on_node(node: Node, variable_name: String, variable_value: Va
 	TMDataUtil.set_variable_by_json_path_string(node_variables_in_all, variable_name, variable_value)
 
 
-func tween_variable_on_node(node: Node, variable: String, to_value: Variant, duration: float, trans: Tween.TransitionType, easing: Tween.EaseType) -> void:
+func tween_variable_on_node(node: Node, variable: String, to_value: Variant, duration: float, trans: Tween.TransitionType = Tween.TRANS_LINEAR, easing: Tween.EaseType = Tween.EASE_IN_OUT) -> void:
 	if to_value is Object:
 		Notify.error("Tween Failed", "Tweening an Object value is not a sensible operation. Aborting.")
 		return
@@ -549,7 +549,7 @@ func _tween_variables_on_nodes_network(nodes_tweened_variables: Dictionary) -> v
 	received_variable_data_change.emit()
 
 
-func _tween_variable_on_node(node: Node, variable_name: String, to_value: Variant, duration: float, trans: Tween.TransitionType, easing: Tween.EaseType) -> void:
+func _tween_variable_on_node(node: Node, variable_name: String, to_value: Variant, duration: float, trans: Tween.TransitionType = Tween.TRANS_LINEAR, easing: Tween.EaseType = Tween.EASE_IN_OUT) -> void:
 	if not node.has_meta(&"MirrorScriptObjectVariables"):
 		node.set_meta(&"MirrorScriptObjectVariables", {})
 	var object_variables: Dictionary = node.get_meta(&"MirrorScriptObjectVariables")

--- a/mirror-godot-app/script/network_sync.gd
+++ b/mirror-godot-app/script/network_sync.gd
@@ -508,6 +508,14 @@ func _set_variable_on_node(node: Node, variable_name: String, variable_value: Va
 		node.set_meta(&"MirrorScriptObjectVariables", {})
 	var object_variables: Dictionary = node.get_meta(&"MirrorScriptObjectVariables")
 	TMDataUtil.set_variable_by_json_path_string(object_variables, variable_name, variable_value)
+	# If this is an exposed script variable, set it in the script.
+	if node.has_method(&"get_script_instances") and Zone.is_host():
+		var script_instances: Array[ScriptInstance] = node.get_script_instances()
+		for script_inst in script_instances:
+			if script_inst is GDScriptInstance and is_instance_valid(script_inst.script_instance_object):
+				var obj = script_inst.script_instance_object
+				if variable_name in obj:
+					obj.set(variable_name, variable_value)
 	# Keep track of all node variables ever set for use with the variable editor.
 	var node_path: NodePath = node.get_path()
 	var node_variables_in_all: Dictionary = _all_set_variables_on_nodes.get_or_add(node_path, {})

--- a/mirror-godot-app/script/script_instance.gd
+++ b/mirror-godot-app/script/script_instance.gd
@@ -87,8 +87,11 @@ func is_script_instance_setup() -> bool:
 
 func setup(node: Node, script_inst_dict: Dictionary) -> void:
 	target_node = node
-	var script_entity_data: Dictionary = await Net.script_client.get_script_entity(script_id)
-	setup_script_entity_data(script_entity_data)
+	var script_entity_data: Dictionary = Net.script_client.get_script_entity(script_id)
+	# If it's empty, we don't have the data yet. The setup_script_entity_data
+	# function will be ran later when we receive the data.
+	if not script_entity_data.is_empty():
+		setup_script_entity_data(script_entity_data)
 
 
 func setup_script_instance_data(script_inst_dict: Dictionary) -> void:
@@ -145,6 +148,17 @@ func update_script_entity_data_from_network(script_entity_data: Dictionary) -> v
 
 
 # Parameter methods.
+func create_inspector_parameter_input(entry_id: String, parameter_port_array: Array) -> void:
+	assert(false, "This method must be overridden in a derived class.")
+
+
+func set_inspector_parameter_input_value(entry_id: String, param_name: String, new_value: Variant) -> void:
+	var parameters_for_entry: Dictionary = entry_parameters[entry_id]
+	var param_data: Array = parameters_for_entry[param_name]
+	param_data[1] = new_value
+	apply_inspector_parameter_values()
+
+
 func _load_entry_parameters_from_json(entry_parameter_json: Dictionary) -> void:
 	assert(entry_parameters.is_empty(), "This method expects to only be called once. If calling multiple times is needed, add support for that.")
 	entry_parameters = entry_parameter_json.duplicate(true)

--- a/mirror-godot-app/script/visual/blocks/misc/get_friendly_name.gd
+++ b/mirror-godot-app/script/visual/blocks/misc/get_friendly_name.gd
@@ -4,19 +4,7 @@ extends ScriptBlock
 func evaluate() -> void:
 	evaluate_inputs()
 	var value = inputs[0].value
-	if value is SpaceObject:
-		outputs[0].value = value.get_space_object_name()
-	elif value is Player:
-		outputs[0].value = value.get_player_name()
-	elif value is Node:
-		outputs[0].value = value.name
-	elif value == null:
-		outputs[0].value = "<null>"
-	elif not is_instance_valid(value):
-		outputs[0].value = "<invalid instance>"
-	else:
-		# For non-Node objects, str() is the best we can do.
-		outputs[0].value = str(value)
+	outputs[0].value = Mirror.get_friendly_name(value)
 
 
 func get_script_block_type() -> String:

--- a/mirror-godot-app/script/visual/blocks/script_block.gd
+++ b/mirror-godot-app/script/visual/blocks/script_block.gd
@@ -109,6 +109,8 @@ func _setup_base(block_json: Dictionary) -> void:
 		graph_position = Serialization.array_to_vector2(block_json["position"])
 	if block_json.has("name"):
 		graph_name = block_json["name"]
+	elif block_json.has("signal"):
+		graph_name = "On " + String(block_json["signal"]).capitalize()
 	else:
 		graph_name = String(block_json["type"]).capitalize()
 

--- a/mirror-godot-app/script/visual/editor/block_creation/script_block_creation_dialog.gd
+++ b/mirror-godot-app/script/visual/editor/block_creation/script_block_creation_dialog.gd
@@ -112,7 +112,7 @@ func _on_confirmed():
 	var desired_block_json: Dictionary = _script_block_creation_menu.get_desired_block_json()
 	if desired_block_json.is_empty():
 		return
-	if desired_block_json["type"] == "entry" and not desired_block_json.has("signal"):
+	if desired_block_json["type"] == "entry" and desired_block_json["signal"] == &"custom_signal":
 		request_show_entry_creation_dialog.emit()
 		return
 	create_block.emit(desired_block_json)

--- a/mirror-godot-app/script/visual/editor/visual_script_editor.gd
+++ b/mirror-godot-app/script/visual/editor/visual_script_editor.gd
@@ -148,7 +148,7 @@ func _on_request_block_creation(constraint: int, data_type: int, index: int, fro
 
 func _on_request_entry_creation(where: Vector2) -> void:
 	_creation_position = where
-	request_show_entry_creation_dialog.emit(_script_instance.target_node)
+	request_show_custom_entry_creation_dialog.emit(_script_instance.target_node)
 
 
 func _on_request_input_value_edit(graph_node: ScriptBlockGraphNode, input_port: ScriptBlock.ScriptBlockInputPort) -> void:

--- a/mirror-godot-app/script/visual/visual_script_instance.gd
+++ b/mirror-godot-app/script/visual/visual_script_instance.gd
@@ -137,6 +137,15 @@ func _create_event_node(entry_block: ScriptBlockEntryBase) -> void:
 	entry_block.entry_node = event_node
 
 
+func create_inspector_parameter_input(entry_id: String, parameter_port_array: Array) -> void:
+	for entry_block in script_builder.entry_blocks:
+		if entry_block.entry_id == entry_id:
+			entry_block.parameters.create_inspector_parameter(parameter_port_array)
+			entry_block.reset_entry_output_ports()
+			break
+	sync_script_inst_params_with_script_data()
+
+
 ## Ensure the script instance entry inspector parameters match the
 ## signature of the script's data. Since a script may be used by
 ## multiple objects, parameters may get out of sync without this code.


### PR DESCRIPTION
First commit: Improve tweening and add print in chat

* Add GDScript object property tween.
* Make trans/easing optional in GDScript.
* Add a helper method for printing to chat in GDScript.
* Add a helper method for getting the friendly name in GDScript.

Second commit: Fix Inspector "Add Input" button

* It used to be hard-coded for visual scripting in the inspector, now there is a method `create_inspector_paramter_input` that is overridden for GDScript and visual scripting separately.
* Previously the GDScript code only did a trivial signal connection, now there is a new method `connect_entry_signal` that can handle the case of connecting the signal with bindings.
* New helper method `set_inspector_parameter_input_value` (no functionality change).
* Also thrown in: Update the script template comment to encourage Notify.info instead of print.

Third commit: Fix custom entry signal creation dialog.

Fourth commit: Sync exposed `@export` vars with SpaceObject space vars

* Now @export vars are saved as space vars, and space vars with a name matching the @export var are loaded in.
* To update the var, `thing = myvalue` won't work, instead one of these options must be used:
    * `set_object_variable(thing, myvalue)`
    * `thing = myvalue` followed by `save_exposed_vars.emit()` (plus there is also `load_exposed_vars.emit()` if you want to read the space vars back into the script vars, this might be useful for sharing data between scripts).
* In both cases, both the thing script var and the thing space variable on the object are updated. Users can use whatever workflow they prefer.

Fifth commit: Add a UI for updating export vars.
<img width="732" alt="Screenshot 2024-05-21 at 8 28 55 PM" src="https://github.com/the-mirror-gdp/the-mirror/assets/1646875/25a03f0e-fa70-4e43-92cc-d05b60ba2a92">

