### PR TITLE
Add "Engine" to GDScript denylist

### DIFF
--- a/mirror-godot-app/script/gd/gdscript_instance.gd
+++ b/mirror-godot-app/script/gd/gdscript_instance.gd
@@ -60,6 +60,7 @@ static var _SCRIPT_TEXT_DENYLIST: Array[RegEx] = [
 	RegEx.create_from_string("\\bget_tree\\b"),
 	RegEx.create_from_string("\\bload\\b"),
 	RegEx.create_from_string("\\bpreload\\b"),
+	RegEx.create_from_string("\\bEngine\\b"),
 	RegEx.create_from_string("\\bOS\\b"),
 	RegEx.create_from_string("\\bResourceLoader\\b"),
 	RegEx.create_from_string("\\bFileAccess\\b"),


### PR DESCRIPTION
Prevents using the `Engine` singleton in user GDScript. https://docs.godotengine.org/en/stable/classes/class_engine.html